### PR TITLE
Display battery + iob instead of only battery

### DIFF
--- a/nightguard WatchKit Extension/InterfaceController.swift
+++ b/nightguard WatchKit Extension/InterfaceController.swift
@@ -202,6 +202,8 @@ class InterfaceController: WKInterfaceController, WKCrownDelegate {
         self.timeLabel.setText(currentNightscoutData.timeString)
         self.timeLabel.setTextColor(UIColorChanger.getTimeLabelColor(currentNightscoutData.time))
         
-        self.batteryLabel.setText(currentNightscoutData.battery)
+        //Display battery + iob instead of only battery
+        self.batteryLabel.setText(currentNightscoutData.batteryIobDisplay)
+        //self.batteryLabel.setText(currentNightscoutData.battery)
     }
 }

--- a/nightguard/MainViewController.swift
+++ b/nightguard/MainViewController.swift
@@ -250,7 +250,9 @@ class MainViewController: UIViewController {
             self.lastUpdateLabel.text = nightscoutData.timeString
             self.lastUpdateLabel.textColor = UIColorChanger.getTimeLabelColor(nightscoutData.time)
             
-            self.batteryLabel.text = nightscoutData.battery
+            //Display battery + iob instead of only battery
+            self.batteryLabel.text = nightscoutData.batteryIobDisplay
+            //self.batteryLabel.text = nightscoutData.battery
         })
     }
     

--- a/nightguard/NightscoutData.swift
+++ b/nightguard/NightscoutData.swift
@@ -44,6 +44,8 @@ class NightscoutData : NSObject, NSCoding {
     }
     var time : NSNumber = 0
     var battery : String = "---"
+    var iob : String = "---"
+    var batteryIobDisplay : String = "---"
     
     // NSCoder methods to make this class serializable
     
@@ -86,6 +88,16 @@ class NightscoutData : NSObject, NSCoding {
             return
         }
         self.battery = battery
+        
+        guard let iob = decoder.decodeObject(forKey: "iob") as? String else {
+            return
+        }
+        self.iob = iob
+        
+        guard let batteryIobDisplay = decoder.decodeObject(forKey: "batteryIobDisplay") as? String else {
+            return
+        }
+        self.batteryIobDisplay = batteryIobDisplay
     }
     
     /*
@@ -98,6 +110,8 @@ class NightscoutData : NSObject, NSCoding {
         aCoder.encode(self.bgdelta, forKey: "bgdelta")
         aCoder.encode(self.time, forKey: "time")
         aCoder.encode(self.battery, forKey: "battery")
+        aCoder.encode(self.iob, forKey: "iob")
+        aCoder.encode(self.batteryIobDisplay, forKey: "batteryIobDisplay")
     }
     
     func isOlderThan5Minutes() -> Bool {

--- a/nightguard/NightscoutService.swift
+++ b/nightguard/NightscoutService.swift
@@ -224,11 +224,41 @@ class NightscoutService {
                     
                     let nightscoutData = NightscoutData()
                     let battery : NSString? = currentBgs.object(forKey: "battery") as? NSString
+                    
+                    //Get Insulin On Board from Nightscout
+                    let iob : NSString? = currentBgs.object(forKey: "iob") as? NSString
+                    
+                    //Define a variable to hold what will be displayed in the app (battery and iob)
+                    var batteryIobDisplay : String = ""
+                    
+                    //If user has battery data in nightscout then add it to what's going to be displayed
+                    if battery != nil {
+                        batteryIobDisplay = batteryIobDisplay + String(battery!) + "%"
+                    }
+                    
+                    //If user has battery data and iob in nightscout then add a separator between the two
+                    if battery != nil && iob != nil {
+                        batteryIobDisplay = batteryIobDisplay + " / "
+                    }
+                    
+                    //If user has iob data in nightscout then add it to what's going to be displayed
+                    if iob != nil {
+                        batteryIobDisplay = batteryIobDisplay + String(iob!) + "U"
+                    }
+                    
                     if battery == nil {
                         nightscoutData.battery = String("?")
                     } else {
                         nightscoutData.battery = String(battery!) + "%"
                     }
+                    
+                    //Save iob data
+                    if iob != nil {
+                        nightscoutData.iob = String(iob!)
+                    }
+                    
+                    //Save display data
+                    nightscoutData.batteryIobDisplay = batteryIobDisplay
 
                     nightscoutData.sgv = String(sgv)
                     nightscoutData.bgdeltaString = self.direction(bgdelta!) + String(format: "%.1f", bgdelta!)


### PR DESCRIPTION
With these modifications, if the user has IOB in Nightscout both the app and the watch will display battery + iob instead of only battery... If the user doesn't use a pump and hence has no battery info in Nightscout then both the app and watch will only display iob. 100% tested!