### PR TITLE
Background updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,23 @@ The dark gray region in the chart marks the values that are between 80 and 180.
 
 This small video shows how to check the configuration and demonstrates the available Apple Watch Complication:
 http://youtu.be/CEcqNyyv_kA
+
+# License
+
+[agpl-3]: http://www.gnu.org/licenses/agpl-3.0.txt
+
+   nightguard app to display cgm readings on your ios and watchos device
+   Copyright (C) 2018 Nightguard contributors.
+   
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Affero General Public License as published
+   by the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+   
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Affero General Public License for more details.
+   
+   You should have received a copy of the GNU Affero General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -25,18 +25,18 @@ http://youtu.be/CEcqNyyv_kA
 
 [agpl-3]: http://www.gnu.org/licenses/agpl-3.0.txt
 
-   nightguard app to display cgm readings on your ios and watchos device
-   Copyright (C) 2018 Nightguard contributors.
-   
-   This program is free software: you can redistribute it and/or modify
-   it under the terms of the GNU Affero General Public License as published
-   by the Free Software Foundation, either version 3 of the License, or
-   (at your option) any later version.
-   
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU Affero General Public License for more details.
-   
-   You should have received a copy of the GNU Affero General Public License
-   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    nightguard app to display cgm readings on your ios and watchos device
+    Copyright (C) 2018 Nightguard contributors.
+    
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+    
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/nightguard WatchKit App/Base.lproj/Interface.storyboard
+++ b/nightguard WatchKit App/Base.lproj/Interface.storyboard
@@ -147,6 +147,18 @@
                                 <fontDescription key="font" type="system" pointSize="10"/>
                             </variation>
                         </label>
+                        <label alignment="center" text="Background updates:" textAlignment="left" id="Gob-MJ-hux">
+                            <fontDescription key="font" type="system" pointSize="15"/>
+                            <variation key="device=watch38mm">
+                                <fontDescription key="font" type="system" pointSize="13"/>
+                            </variation>
+                        </label>
+                        <label alignment="center" text="0" numberOfLines="0" id="XcE-eq-aUV">
+                            <fontDescription key="font" type="system" pointSize="12"/>
+                            <variation key="device=watch38mm">
+                                <fontDescription key="font" type="system" pointSize="10"/>
+                            </variation>
+                        </label>
                         <button width="1" height="31" alignment="left" title="Close" id="J0t-oX-olu">
                             <connections>
                                 <action selector="doCloseAction" destination="wky-cb-ykJ" id="J6Y-PP-x8b"/>
@@ -154,6 +166,7 @@
                         </button>
                     </items>
                     <connections>
+                        <outlet property="backgroundUpdatesLabel" destination="XcE-eq-aUV" id="i3o-WH-bxk"/>
                         <outlet property="cachedValuesLabel" destination="IeJ-DT-Wcg" id="edG-OD-P0g"/>
                         <outlet property="serverUriLabel" destination="rQn-yu-ajp" id="chR-Cb-I8J"/>
                         <outlet property="versionLabel" destination="VJk-AO-PXu" id="9Je-rN-Q8U"/>

--- a/nightguard WatchKit Extension/AppMessageService.swift
+++ b/nightguard WatchKit Extension/AppMessageService.swift
@@ -59,7 +59,9 @@ class AppMessageService : NSObject, WCSessionDelegate {
         if let _ = applicationContext["nightscoutData"] {
             if #available(watchOSApplicationExtension 3.0, *) {
                 if let extensionDelegate = WKExtension.shared().delegate as? ExtensionDelegate {
-                    extensionDelegate.handleNightscoutDataMessage(applicationContext)
+                    DispatchQueue.main.async {
+                        extensionDelegate.handleNightscoutDataMessage(applicationContext)
+                    }
                 }
             }
         }

--- a/nightguard WatchKit Extension/AppMessageService.swift
+++ b/nightguard WatchKit Extension/AppMessageService.swift
@@ -76,8 +76,12 @@ class AppMessageService : NSObject, WCSessionDelegate {
     @available(watchOS 2.0, *)
     func session(_ session: WCSession, didReceiveUserInfo userInfo: [String : Any]) {
         if let _ = userInfo["nightscoutData"] {
-            if let extensionDelegate = WKExtension.shared().delegate as? ExtensionDelegate {
-                extensionDelegate.handleNightscoutDataMessage(userInfo)
+            if #available(watchOSApplicationExtension 3.0, *) {
+                if let extensionDelegate = WKExtension.shared().rootInterfaceController as? InterfaceController {
+                    extensionDelegate.handleNightscoutDataMessage(userInfo)
+                }
+            } else {
+                // Fallback on earlier versions
             }
         } else {
             updateValuesFromApplicationContext(userInfo as [String : AnyObject])

--- a/nightguard WatchKit Extension/AppMessageService.swift
+++ b/nightguard WatchKit Extension/AppMessageService.swift
@@ -75,6 +75,7 @@ class AppMessageService : NSObject, WCSessionDelegate {
     /** Called on the delegate of the receiver. Will be called on startup if the user info finished transferring when the receiver was not running. */
     @available(watchOS 2.0, *)
     func session(_ session: WCSession, didReceiveUserInfo userInfo: [String : Any]) {
+        
         if let _ = userInfo["nightscoutData"] {
             if #available(watchOSApplicationExtension 3.0, *) {
                 if let extensionDelegate = WKExtension.shared().rootInterfaceController as? InterfaceController {

--- a/nightguard WatchKit Extension/AppMessageService.swift
+++ b/nightguard WatchKit Extension/AppMessageService.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import WatchKit
 import WatchConnectivity
 
 // This class handles values that are passed from the ios app.
@@ -74,6 +75,12 @@ class AppMessageService : NSObject, WCSessionDelegate {
     /** Called on the delegate of the receiver. Will be called on startup if the user info finished transferring when the receiver was not running. */
     @available(watchOS 2.0, *)
     func session(_ session: WCSession, didReceiveUserInfo userInfo: [String : Any]) {
-        updateValuesFromApplicationContext(userInfo as [String : AnyObject])
+        if let _ = userInfo["nightscoutData"] {
+            if let extensionDelegate = WKExtension.shared().delegate as? ExtensionDelegate {
+                extensionDelegate.handleNightscoutDataMessage(userInfo)
+            }
+        } else {
+            updateValuesFromApplicationContext(userInfo as [String : AnyObject])
+        }
     }
 }

--- a/nightguard WatchKit Extension/AppMessageService.swift
+++ b/nightguard WatchKit Extension/AppMessageService.swift
@@ -58,7 +58,7 @@ class AppMessageService : NSObject, WCSessionDelegate {
         
         if let _ = applicationContext["nightscoutData"] {
             if #available(watchOSApplicationExtension 3.0, *) {
-                if let extensionDelegate = WKExtension.shared().rootInterfaceController as? InterfaceController {
+                if let extensionDelegate = WKExtension.shared().delegate as? ExtensionDelegate {
                     extensionDelegate.handleNightscoutDataMessage(applicationContext)
                 }
             }

--- a/nightguard WatchKit Extension/AppMessageService.swift
+++ b/nightguard WatchKit Extension/AppMessageService.swift
@@ -55,6 +55,14 @@ class AppMessageService : NSObject, WCSessionDelegate {
             defaults!.setValue(alertIfBelowValue, forKey: "alertIfBelowValue")
             AlarmRule.alertIfBelowValue = alertIfBelowValue
         }
+        
+        if let _ = applicationContext["nightscoutData"] {
+            if #available(watchOSApplicationExtension 3.0, *) {
+                if let extensionDelegate = WKExtension.shared().rootInterfaceController as? InterfaceController {
+                    extensionDelegate.handleNightscoutDataMessage(applicationContext)
+                }
+            }
+        }
     }
     
     @available(watchOSApplicationExtension 2.2, *)
@@ -75,17 +83,6 @@ class AppMessageService : NSObject, WCSessionDelegate {
     /** Called on the delegate of the receiver. Will be called on startup if the user info finished transferring when the receiver was not running. */
     @available(watchOS 2.0, *)
     func session(_ session: WCSession, didReceiveUserInfo userInfo: [String : Any]) {
-        
-        if let _ = userInfo["nightscoutData"] {
-            if #available(watchOSApplicationExtension 3.0, *) {
-                if let extensionDelegate = WKExtension.shared().rootInterfaceController as? InterfaceController {
-                    extensionDelegate.handleNightscoutDataMessage(userInfo)
-                }
-            } else {
-                // Fallback on earlier versions
-            }
-        } else {
-            updateValuesFromApplicationContext(userInfo as [String : AnyObject])
-        }
+        updateValuesFromApplicationContext(userInfo as [String : AnyObject])
     }
 }

--- a/nightguard WatchKit Extension/BackgroundRefreshLogger.swift
+++ b/nightguard WatchKit Extension/BackgroundRefreshLogger.swift
@@ -13,6 +13,7 @@ class BackgroundRefreshLogger {
     static var logs: [String] = []
     
     // keep some background refrehs related stats data...
+    static var backgroundRefreshes: Int = 0
     static var backgroundURLSessions: Int = 0
     static var backgroundURLSessionUpdatesWithNewData: Int = 0
     static var backgroundURLSessionUpdatesWithSameData: Int = 0
@@ -22,11 +23,67 @@ class BackgroundRefreshLogger {
     static var phoneUpdatesWithSameData: Int = 0
     static var phoneUpdatesWithOldData: Int = 0
     
+    static var backgroundRefreshesPerHour: Double {
+        guard let logStartTime = BackgroundRefreshLogger.logStartTime else {
+            return 0
+        }
+        
+        let minutes: Double = Date().timeIntervalSince(logStartTime) / 60
+        let refreshesPerMinute = Double(backgroundRefreshes) / minutes
+        return refreshesPerMinute * 60
+    }
+    
+    static var formattedBackgroundRefreshesPerHour: String {
+        return String(format: "%.2f", backgroundRefreshesPerHour)
+    }
+    
+    static var backgroundRefreshesStartingURLSessions: Double {
+        return backgroundRefreshes != 0 ? Double(backgroundURLSessions) / Double(backgroundRefreshes) : 0
+    }
+    
+    static var formattedBackgroundRefreshesStartingURLSessions: String {
+        return String(format: "%.2f%%", backgroundRefreshesStartingURLSessions)
+    }
+    
+    private static var logStartTime: Date?
+    
     static func info(_ text: String) {
+        resetStatsDataIfNeeded()
+        
         let timeFormatter = DateFormatter()
         timeFormatter.dateFormat = "HH:mm:ss"
         let dateString = timeFormatter.string(from: Date())
         
         logs.append(dateString + " " + text)
+    }
+    
+    private static func resetStatsDataIfNeeded() {
+        
+        guard let logStartTime = BackgroundRefreshLogger.logStartTime else {
+            BackgroundRefreshLogger.logStartTime = Date()
+            return
+        }
+        
+        let now = Date()
+        let unitFlags:Set<Calendar.Component> = [.day]
+        let nowDateComponents = Calendar.current.dateComponents(unitFlags, from: logStartTime)
+        let logStartDateComponents = Calendar.current.dateComponents(unitFlags, from: now)
+
+        // keep log data only for one day (from 00:00 until 23:59)
+        if logStartDateComponents.day != nowDateComponents.day {
+            
+            // reset log data
+            logs.removeAll()
+            
+            backgroundRefreshes = 0
+            backgroundURLSessions = 0
+            backgroundURLSessionUpdatesWithNewData = 0
+            backgroundURLSessionUpdatesWithSameData = 0
+            backgroundURLSessionUpdatesWithOldData = 0
+            phoneUpdates = 0
+            phoneUpdatesWithNewData = 0
+            phoneUpdatesWithSameData = 0
+            phoneUpdatesWithOldData = 0
+        }
     }
 }

--- a/nightguard WatchKit Extension/BackgroundRefreshLogger.swift
+++ b/nightguard WatchKit Extension/BackgroundRefreshLogger.swift
@@ -42,13 +42,18 @@ class BackgroundRefreshLogger {
     }
     
     static var formattedBackgroundRefreshesStartingURLSessions: String {
-        return String(format: "%.2f%%", backgroundRefreshesStartingURLSessions)
+        return "\(Int(backgroundRefreshesStartingURLSessions * 100))%"
     }
     
     private static var logStartTime: Date?
+    private static let showLogs = (Bundle.main.infoDictionary?["ShowLogsFromBackgroundRefreshTasks"] as? Bool) ?? false
     
     static func info(_ text: String) {
         resetStatsDataIfNeeded()
+        
+        guard showLogs else {
+            return
+        }
         
         let timeFormatter = DateFormatter()
         timeFormatter.dateFormat = "HH:mm:ss"

--- a/nightguard WatchKit Extension/BackgroundRefreshLogger.swift
+++ b/nightguard WatchKit Extension/BackgroundRefreshLogger.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+// A debugging tool that keeps info about the nightscout data updates obtained through background tasks (URL sessions) or updates received from the phone app (that also relies on background fetch for refreshing its data).
 class BackgroundRefreshLogger {
     
     static var logs: [String] = []
@@ -118,6 +119,7 @@ class BackgroundRefreshLogger {
             
             // reset log data
             logs.removeAll()
+            receivedData.removeAll()
             
             backgroundRefreshes = 0
             backgroundURLSessions = 0

--- a/nightguard WatchKit Extension/BackgroundRefreshLogger.swift
+++ b/nightguard WatchKit Extension/BackgroundRefreshLogger.swift
@@ -1,0 +1,32 @@
+//
+//  BackgroundRefreshLogger.swift
+//  nightguard WatchKit Extension
+//
+//  Created by Florian Preknya on 3/16/18.
+//  Copyright © 2018 private. All rights reserved.
+//
+
+import Foundation
+
+class BackgroundRefreshLogger {
+    
+    static var logs: [String] = []
+    
+    // keep some background refrehs related stats data...
+    static var backgroundURLSessions: Int = 0
+    static var backgroundURLSessionUpdatesWithNewData: Int = 0
+    static var backgroundURLSessionUpdatesWithSameData: Int = 0
+    static var backgroundURLSessionUpdatesWithOldData: Int = 0
+    static var phoneUpdates: Int = 0
+    static var phoneUpdatesWithNewData: Int = 0
+    static var phoneUpdatesWithSameData: Int = 0
+    static var phoneUpdatesWithOldData: Int = 0
+    
+    static func info(_ text: String) {
+        let timeFormatter = DateFormatter()
+        timeFormatter.dateFormat = "HH:mm:ss"
+        let dateString = timeFormatter.string(from: Date())
+        
+        logs.append(dateString + " " + text)
+    }
+}

--- a/nightguard WatchKit Extension/BackgroundRefreshLogger.swift
+++ b/nightguard WatchKit Extension/BackgroundRefreshLogger.swift
@@ -11,6 +11,7 @@ import Foundation
 class BackgroundRefreshLogger {
     
     static var logs: [String] = []
+    static var receivedData: [String] = []
     
     // keep some background refrehs related stats data...
     static var backgroundRefreshes: Int = 0
@@ -60,6 +61,44 @@ class BackgroundRefreshLogger {
         if showLogs {
             logs.append(logEntry)
         }
+    }
+    
+    
+    static func nightscoutDataReceived(_ nightscoutData: NightscoutData, updateResult: ExtensionDelegate.UpdateResult, updateSource: ExtensionDelegate.UpdateSource) {
+        
+        let timeFormatter = DateFormatter()
+        timeFormatter.dateFormat = "HH:mm:ss"
+        let dateString = timeFormatter.string(from: Date())
+        
+        var updateSourceString = ""
+        switch updateSource {
+        case .phoneApp :
+            updateSourceString = "📱"
+        default:
+            updateSourceString = "⌚"
+        }
+        
+        var updateResultString = ""
+        switch updateResult {
+        case .updated:
+            updateResultString = "NEW"
+        case .updateDataAlreadyExists:
+            updateResultString = "EXISTING"
+        case .updateDataIsOld:
+            updateResultString = "OLD"
+        }
+        
+        let nightscoutDataTime = Date(timeIntervalSince1970: nightscoutData.time.doubleValue / 1000)
+        timeFormatter.dateFormat = "HH:mm"
+        let nightscoutDataTimeString = timeFormatter.string(from: nightscoutDataTime)
+        
+        let logEntry = dateString + " " + updateSourceString + updateResultString + " (\(nightscoutData.sgv)@\(nightscoutDataTimeString))"
+        NSLog(logEntry)
+        
+        if showLogs {
+            receivedData.append(logEntry)
+        }
+        
     }
     
     private static func resetStatsDataIfNeeded() {

--- a/nightguard WatchKit Extension/BackgroundRefreshLogger.swift
+++ b/nightguard WatchKit Extension/BackgroundRefreshLogger.swift
@@ -48,7 +48,7 @@ class BackgroundRefreshLogger {
     }
     
     private static var logStartTime: Date?
-    private static let showLogs = (Bundle.main.infoDictionary?["ShowLogsFromBackgroundRefreshTasks"] as? Bool) ?? false
+    private static let showLogs = BackgroundRefreshSettings.showBackgroundTasksLogs
     
     static func info(_ text: String) {
         resetStatsDataIfNeeded()

--- a/nightguard WatchKit Extension/BackgroundRefreshLogger.swift
+++ b/nightguard WatchKit Extension/BackgroundRefreshLogger.swift
@@ -51,15 +51,15 @@ class BackgroundRefreshLogger {
     static func info(_ text: String) {
         resetStatsDataIfNeeded()
         
-        guard showLogs else {
-            return
-        }
-        
         let timeFormatter = DateFormatter()
         timeFormatter.dateFormat = "HH:mm:ss"
         let dateString = timeFormatter.string(from: Date())
+        let logEntry = dateString + " " + text
+        NSLog(logEntry)
         
-        logs.append(dateString + " " + text)
+        if showLogs {
+            logs.append(logEntry)
+        }
     }
     
     private static func resetStatsDataIfNeeded() {

--- a/nightguard WatchKit Extension/BackgroundRefreshScheduler.swift
+++ b/nightguard WatchKit Extension/BackgroundRefreshScheduler.swift
@@ -32,7 +32,7 @@ class BackgroundRefreshScheduler {
     func schedule() {
         
         guard BackgroundRefreshSettings.enableBackgroundTasks else {
-            BackgroundRefreshLogger.info("Background tasks are DISABLED")
+            print("Background tasks are disabled!")
             return
         }
         

--- a/nightguard WatchKit Extension/BackgroundRefreshScheduler.swift
+++ b/nightguard WatchKit Extension/BackgroundRefreshScheduler.swift
@@ -23,14 +23,18 @@ class BackgroundRefreshScheduler {
     
     static let instance = BackgroundRefreshScheduler()
     
-    var refreshRate: Int = 10 // every 10 minutes by default (even if the watchOS will not do it that often...)
-    
+    private let refreshRate: Int = BackgroundRefreshSettings.backgroundTaskScheduleRate
     private var lastScheduledTime: Date?
     
     private init() {
     }
     
     func schedule() {
+        
+        guard BackgroundRefreshSettings.enableBackgroundTasks else {
+            BackgroundRefreshLogger.info("Background tasks are DISABLED")
+            return
+        }
         
         // obtain the refresh time
         let scheduleTime = nextScheduleTime(refreshRate: self.refreshRate)

--- a/nightguard WatchKit Extension/BackgroundRefreshScheduler.swift
+++ b/nightguard WatchKit Extension/BackgroundRefreshScheduler.swift
@@ -1,0 +1,109 @@
+//
+//  BackgroundRefreshScheduler.swift
+//  nightguard WatchKit Extension
+//
+//  Created by Florian Preknya on 3/16/18.
+//  Copyright © 2018 private. All rights reserved.
+//
+
+import Foundation
+import WatchKit
+
+/// This class is responsible with scheduling the next refreshes (background and snapshot). It will trigger a
+/// background (or snapshot) refresh as configured by the refreshRate property, the exact refresh moment will
+/// be determined by dividing the hour in periods (starting from 0 minutes -> 60 minutes), the most apropiate
+/// period start will be the next scheduled value.
+///
+/// For example, if the refresh rate is 4 (4 refreshes per hour, the refresh period is 15 minutes), the
+/// scheduled times will be xx:00, xx:15, xx:30 and xx:45. If calling schedule() at xx:18, the next refresh
+/// will be scheduled at xx:30. NOTE that watchOS can delay (or even skip!) calling the WKExtensionDelegate.handle(_) method on scheduled time (the delay can be from seconds to some minutes).
+@available(watchOSApplicationExtension 3.0, *)
+class BackgroundRefreshScheduler {
+    
+    static let instance = BackgroundRefreshScheduler()
+    
+    // number of refreshes per hour (for e.g, if refreshRate = 6, it will trigger a refresh every 10 minute)
+    var refreshRate: Int = 12 // every 5 minutes by default (even if the watchOS will not do it that often...)
+    
+    // alternate background refreshes with snapshot refreshes
+    var alternateSnaphotRefreshes = true
+    
+    var lastScheduledWasSnapshotRefresh = false
+    private var lastScheduledTime: Date?
+    
+    private init() {
+    }
+    
+    func schedule() {
+        
+        // obtain base refresh time
+        let scheduleTime = nextScheduleTime(refreshRate: self.refreshRate)
+        
+        // if the background refresh alternates with the snapshot refresh, the second schedule time will be the current schedule time delayed with a period (5 more minutes if the period is 5 minutes); if using only background refreshes, then still schedule snapshot refreshes every 15 minutes... just for triggering another schedule for the background refreshes (because some background refreshes can be skipped and the refresh scheduling will not be called anymore!)
+        let refreshPeriod = 60 / refreshRate
+        let secondScheduleTime = alternateSnaphotRefreshes ? Calendar.current.date(byAdding: .minute, value: refreshPeriod, to: scheduleTime)! : nextScheduleTime(refreshRate: 4)
+        
+        // log ONLY once
+        let logRefreshTime = self.lastScheduledTime != scheduleTime
+        self.lastScheduledTime = scheduleTime
+        
+        var backgroundRefreshTime = scheduleTime
+        var snapshotRefreshTime = secondScheduleTime
+        if alternateSnaphotRefreshes && !lastScheduledWasSnapshotRefresh {
+            swap(&backgroundRefreshTime, &snapshotRefreshTime)
+        }
+        
+        WKExtension.shared().scheduleBackgroundRefresh(withPreferredDate: backgroundRefreshTime, userInfo: nil) { (error: Error?) in
+            
+            if logRefreshTime {
+                BackgroundRefreshLogger.info("Scheduled next background refresh at \(self.formatted(scheduleTime: backgroundRefreshTime))")
+            }
+            
+            if let error = error {
+                BackgroundRefreshLogger.info("Error occurred while scheduling background refresh: \(error.localizedDescription)")
+            }
+        }
+        
+        WKExtension.shared().scheduleSnapshotRefresh(withPreferredDate: snapshotRefreshTime, userInfo: nil) { (error: Error?) in
+            
+            if logRefreshTime {
+                BackgroundRefreshLogger.info("Scheduled next snapshot refresh at \(self.formatted(scheduleTime: snapshotRefreshTime))")
+            }
+            
+            if let error = error {
+                BackgroundRefreshLogger.info("Error occurred while scheduling snapshot refresh: \(error.localizedDescription)")
+            }
+        }
+    }
+    
+    private func nextScheduleTime(refreshRate: Int) -> Date {
+        
+        let now = Date()
+        let unitFlags:Set<Calendar.Component> = [
+            .hour, .day, .month,
+            .year,.minute,.hour,.second,
+            .calendar]
+        var dateComponents = Calendar.current.dateComponents(unitFlags, from: now)
+        
+        // reset second
+        dateComponents.second = 0
+        
+        let refreshPeriod = 60 / refreshRate
+        
+        let nextRefreshMinute = ((dateComponents.minute! / refreshPeriod) + 1) * refreshPeriod
+        dateComponents.minute = nextRefreshMinute % 60
+        
+        var scheduleTime = Calendar.current.date(from: dateComponents)!
+        if nextRefreshMinute >= 60 {
+            scheduleTime = Calendar.current.date(byAdding: .hour, value: 1, to: scheduleTime)!
+        }
+        
+        return scheduleTime
+    }
+    
+    private func formatted(scheduleTime: Date) -> String {
+        let timeFormatter = DateFormatter()
+        timeFormatter.dateFormat = "HH:mm"
+        return timeFormatter.string(from: scheduleTime)
+    }
+}

--- a/nightguard WatchKit Extension/BackgroundRefreshScheduler.swift
+++ b/nightguard WatchKit Extension/BackgroundRefreshScheduler.swift
@@ -14,16 +14,16 @@ import WatchKit
 /// be determined by dividing the hour in periods (starting from 0 minutes -> 60 minutes), the most apropiate
 /// period start will be the next scheduled value.
 ///
-/// For example, if the refresh rate is 4 (4 refreshes per hour, the refresh period is 15 minutes), the
-/// scheduled times will be xx:00, xx:15, xx:30 and xx:45. If calling schedule() at xx:18, the next refresh
-/// will be scheduled at xx:30. NOTE that watchOS can delay (or even skip!) calling the WKExtensionDelegate.handle(_) method on scheduled time (the delay can be from seconds to some minutes).
+/// For example, if the refresh rate is 15 (minutes), the scheduled times will be xx:00, xx:15, xx:30 and xx:45.
+/// If calling schedule() at xx:18, the next refresh will be scheduled at xx:30. NOTE that watchOS can delay (or
+/// even skip!) calling the WKExtensionDelegate.handle(_) method on scheduled time (the delay can be from seconds
+/// to some minutes).
 @available(watchOSApplicationExtension 3.0, *)
 class BackgroundRefreshScheduler {
     
     static let instance = BackgroundRefreshScheduler()
     
-    // number of refreshes per hour (for e.g, if refreshRate = 6, it will trigger a refresh every 10 minute)
-    var refreshRate: Int = 12 // every 10 minutes by default (even if the watchOS will not do it that often...)
+    var refreshRate: Int = 10 // every 10 minutes by default (even if the watchOS will not do it that often...)
     
     private var lastScheduledTime: Date?
     
@@ -63,9 +63,7 @@ class BackgroundRefreshScheduler {
         // reset second
         dateComponents.second = 0
         
-        let refreshPeriod = 60 / refreshRate
-        
-        let nextRefreshMinute = ((dateComponents.minute! / refreshPeriod) + 1) * refreshPeriod
+        let nextRefreshMinute = ((dateComponents.minute! / refreshRate) + 1) * refreshRate
         dateComponents.minute = nextRefreshMinute % 60
         
         var scheduleTime = Calendar.current.date(from: dateComponents)!

--- a/nightguard WatchKit Extension/BackgroundRefreshSettings.swift
+++ b/nightguard WatchKit Extension/BackgroundRefreshSettings.swift
@@ -1,0 +1,37 @@
+//
+//  BackgroundRefreshSettings.swift
+//  nightguard WatchKit Extension
+//
+//  Created by Florian Preknya on 3/22/18.
+//  Copyright © 2018 private. All rights reserved.
+//
+
+import Foundation
+
+/// All the configurable aspects related to background updates.
+class BackgroundRefreshSettings {
+    
+    // enable background tasks in watch app that will schedule the URL sessions for requesting new nightscout data (used in watch app)
+    static let enableBackgroundTasks: Bool = true
+    
+    // the background tasks scheduling rate (period between two schedules) (used in watch app)
+    // NOTE that the current implementation (BackgroundRefreshScheduler class) will schedule background tasks at fixed moments taking as reference the current hour timeframe (for eg, if the refresh rate is 15 minutes, the scheduled times will be xx:00, xx:15, xx:30 and xx:45). Check BackgroundRefreshScheduler implementation for more info.
+    static let backgroundTaskScheduleRate: Int = 15 /* minutes */
+    
+    // enable watch app updates from phone app when receives new nightscout data (used in phone app)
+    static let enableWatchUpdate: Bool = true
+    
+    // watch app update frequency, initiated by phone app when receives new nightscout data (used in phone app)
+    static let watchUpdateRate: Int = 5 /* minutes */
+    
+    // enable watch complication updates from phone app when receives new nightscout data (used in phone app)
+    // NOTE: complication update is not really needed anymore if using regular watch updates (because both updates will arrive at same time, providing the same nightscout data - consuming only the watch app's background quota...)
+    static let enableWatchComplicationUpdate: Bool = false
+
+    // watch complication update frequency, initiated by phone app when receives new nightscout data (used in phone app)
+    static let watchComplicationUpdateRate: Int = 30 /* minutes - (50 complication update per day guaranteed by Apple...)*/
+    
+
+    // enable/disable show of logs in the watch app Info screen, usefull for debugging background activity (used in watch app)
+    static let showBackgroundTasksLogs: Bool = true
+}

--- a/nightguard WatchKit Extension/BackgroundRefreshSettings.swift
+++ b/nightguard WatchKit Extension/BackgroundRefreshSettings.swift
@@ -19,7 +19,7 @@ class BackgroundRefreshSettings {
     
     // the background tasks scheduling rate (period between two schedules) (used in watch app)
     // NOTE that the current implementation (BackgroundRefreshScheduler class) will schedule background tasks at fixed moments taking as reference the current hour timeframe (for eg, if the refresh rate is 15 minutes, the scheduled times will be xx:00, xx:15, xx:30 and xx:45). Check BackgroundRefreshScheduler implementation for more info.
-    static let backgroundTaskScheduleRate: Int = 15 /* minutes */
+    static let backgroundTaskScheduleRate: Int = 5 /* minutes */
     
     // enable watch app updates from phone app when receives new nightscout data (used in phone app)
     static let enableWatchUpdate: Bool = true

--- a/nightguard WatchKit Extension/BackgroundRefreshSettings.swift
+++ b/nightguard WatchKit Extension/BackgroundRefreshSettings.swift
@@ -8,8 +8,11 @@
 
 import Foundation
 
-/// All the configurable aspects related to background updates.
+/// All the configurable aspects related to background updates, used in phone & watch apps.
 class BackgroundRefreshSettings {
+    
+    // the minimum background fetch interval for updating nightscout data while the phone app is in background (used in phone app)
+    static let backgroundFetchInterval: Int = 5 /* minutes */
     
     // enable background tasks in watch app that will schedule the URL sessions for requesting new nightscout data (used in watch app)
     static let enableBackgroundTasks: Bool = true
@@ -22,7 +25,7 @@ class BackgroundRefreshSettings {
     static let enableWatchUpdate: Bool = true
     
     // watch app update frequency, initiated by phone app when receives new nightscout data (used in phone app)
-    static let watchUpdateRate: Int = 5 /* minutes */
+    static let watchUpdateRate: Int = 0 /* minutes - if 0, then no update rate is used, the watch is updated each time a new nightscout data appears */
     
     // enable watch complication updates from phone app when receives new nightscout data (used in phone app)
     // NOTE: complication update is not really needed anymore if using regular watch updates (because both updates will arrive at same time, providing the same nightscout data - consuming only the watch app's background quota...)

--- a/nightguard WatchKit Extension/ComplicationController.swift
+++ b/nightguard WatchKit Extension/ComplicationController.swift
@@ -127,7 +127,11 @@ class ComplicationController: NSObject, CLKComplicationDataSource {
         return Float(difference)
     }
     
-    func getRelativeDateTextProvider(for time: NSNumber) -> CLKRelativeDateTextProvider {
+    func getRelativeDateTextProvider(for time: NSNumber) -> CLKTextProvider {
+        
+        guard time.doubleValue > 0 else {
+            return CLKSimpleTextProvider(text: "???")
+        }
         
         let date: Date = Date(timeIntervalSince1970: time.doubleValue / 1000)
         

--- a/nightguard WatchKit Extension/ExtensionDelegate.swift
+++ b/nightguard WatchKit Extension/ExtensionDelegate.swift
@@ -152,6 +152,11 @@ extension ExtensionDelegate {
             return false
         }
         
+        guard !nightscoutData.isOlderThanXMinutes(60) else {
+            BackgroundRefreshLogger.info("📱Rejected nightscout data (>1hr old!)")
+            return false
+        }
+
         let updateComplication = message["updateComplication"] as? Bool ?? false
         BackgroundRefreshLogger.info("📱Updating nightscout data (update complication: \(updateComplication))")
         

--- a/nightguard WatchKit Extension/ExtensionDelegate.swift
+++ b/nightguard WatchKit Extension/ExtensionDelegate.swift
@@ -19,7 +19,7 @@ extension InterfaceController: WKExtensionDelegate {
     func applicationDidFinishLaunching() {
         
         // Initialize the BackgroundUrlSession. This has to be an singleton that is used throughout the whole app
-        BackgroundUrlSessionWrapper.setup(delegate: self)
+//        BackgroundUrlSessionWrapper.setup(delegate: self)
         // Perform any final initialization of your application.
         activateWatchConnectivity()
     }
@@ -92,6 +92,7 @@ extension InterfaceController {
         print("WKSnapshotRefreshBackgroundTask received")
         
         if BackgroundRefreshScheduler.instance.alternateSnaphotRefreshes {
+            BackgroundRefreshLogger.backgroundRefreshes += 1
             
             // implement this exactly as a refresh task... by scheduling an URL session..
             scheduleURLSessionIfNeeded()
@@ -108,6 +109,7 @@ extension InterfaceController {
         
         print("WKApplicationRefreshBackgroundTask received")
         
+        BackgroundRefreshLogger.backgroundRefreshes += 1
         scheduleURLSessionIfNeeded()
         BackgroundRefreshScheduler.instance.lastScheduledWasSnapshotRefresh = false
         

--- a/nightguard WatchKit Extension/ExtensionDelegate.swift
+++ b/nightguard WatchKit Extension/ExtensionDelegate.swift
@@ -199,7 +199,7 @@ extension InterfaceController {
         // reset second
         dateComponents.second = 0
         
-        let refreshRate = 12  // number of refreshes per hour
+        let refreshRate = 12  // number of refreshes per hour (change to 4/6/12.. etc)
         let refreshPeriod = 60 / refreshRate
         
         let nextRefreshMinute = ((dateComponents.minute! / refreshPeriod) + 1) * refreshPeriod

--- a/nightguard WatchKit Extension/ExtensionDelegate.swift
+++ b/nightguard WatchKit Extension/ExtensionDelegate.swift
@@ -199,22 +199,14 @@ extension InterfaceController {
         // reset second
         dateComponents.second = 0
         
-        var incrementHour = false
-        if let minute = dateComponents.minute {
-            if (0..<15).contains(minute) {
-                dateComponents.minute = 15
-            } else if (15..<30).contains(minute) {
-                dateComponents.minute = 30
-            } else if (30..<45).contains(minute) {
-                dateComponents.minute = 45
-            } else {
-                dateComponents.minute = 0
-                incrementHour = true
-            }
-        }
+        let refreshRate = 12  // number of refreshes per hour
+        let refreshPeriod = 60 / refreshRate
+        
+        let nextRefreshMinute = ((dateComponents.minute! / refreshPeriod) + 1) * refreshPeriod
+        dateComponents.minute = nextRefreshMinute % 60
         
         var scheduleTime = Calendar.current.date(from: dateComponents)!
-        if incrementHour {
+        if nextRefreshMinute >= 60 {
             scheduleTime = Calendar.current.date(byAdding: .hour, value: 1, to: scheduleTime)!
         }
         

--- a/nightguard WatchKit Extension/ExtensionDelegate.swift
+++ b/nightguard WatchKit Extension/ExtensionDelegate.swift
@@ -39,6 +39,11 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
         
         // keep myself in class property (see above why...)
         ExtensionDelegate.singleton = self
+        
+        BackgroundRefreshLogger.info("Application did finish launching")
+        if #available(watchOSApplicationExtension 3.0, *) {
+            scheduleBackgroundRefresh()
+        }
     }
 
     func activateWatchConnectivity() {

--- a/nightguard WatchKit Extension/ExtensionDelegate.swift
+++ b/nightguard WatchKit Extension/ExtensionDelegate.swift
@@ -9,17 +9,31 @@
 import WatchKit
 import WatchConnectivity
 
-class ExtensionDelegate: NSObject, WKExtensionDelegate, URLSessionDelegate {
+class ExtensionDelegate: NSObject, WKExtensionDelegate {
 
     var session: WCSession? {
         didSet {
             if let session = session {
                 session.delegate = AppMessageService.singleton
                 session.activate()
+                
+                // https://developer.apple.com/library/content/samplecode/QuickSwitch/Listings/QuickSwitch_WatchKit_Extension_ExtensionDelegate_swift.html
+                session.addObserver(self, forKeyPath: "activationState", options: [], context: nil)
+                session.addObserver(self, forKeyPath: "hasContentPending", options: [], context: nil)
             }
         }
     }
     
+    var watchConnectivityBackgroundTasks: [Any] = []
+    
+    // debugging info for background refresh
+    var ndRequests: Int = 0
+    var ndResponses: Int = 0
+    var ndRequestErrorMessages: [String] = []
+    var ndUpdates: Int = 0
+    var ndUpdatesSucceded: Int = 0
+    var ndOldUpdateData: Int = 0
+
     func applicationDidFinishLaunching() {
         
         // Initialize the BackgroundUrlSession. This has to be an singleton that is used throughout the whole app
@@ -44,7 +58,7 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate, URLSessionDelegate {
         
         print("Application will resign active.")
         if #available(watchOSApplicationExtension 3.0, *) {
-            scheduleBackgroundUpdate()
+            scheduleBackgroundRefresh()
         }
     }
     
@@ -54,52 +68,154 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate, URLSessionDelegate {
         let initialDefaults: NSDictionary = ["maximumBloodGlucoseDisplayed": 350]
         UserDefaults.standard.register(defaults: initialDefaults as! [String : AnyObject])
     }
+    
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        DispatchQueue.main.async {
+            if #available(watchOSApplicationExtension 3, *) {
+                self.completeAllTasksIfReady()
+            } else {
+                // Fallback on earlier versions
+            }
+        }
+    }
 
     @available(watchOSApplicationExtension 3.0, *)
     public func handle(_ backgroundTasks: Set<WKRefreshBackgroundTask>) {
         
-        for task : WKRefreshBackgroundTask in backgroundTasks {
-            print("received background task: \(task)\n")
-            // only handle these while running in the background
-            if (WKExtension.shared().applicationState == .background) {
-                switch task {
-                    case _ as WKApplicationRefreshBackgroundTask:
-                        // this task is completed below, our app will then suspend while the download session runs
-                        print("WKApplicationRefreshBackgroundTask received, start URL session")
-                        //let _ = NightscoutCacheService.singleton.loadCurrentNightscoutDataInBackground()
-                        task.setTaskCompleted()
-                    case let sessionTask as WKURLSessionRefreshBackgroundTask:
-                        
-                         print("WKURLSessionRefreshTaskReceived, start URL session")
-                         
-                        let backgroundSession = BackgroundUrlSessionWrapper.singleton
-//                        let backgroundConfigObject = URLSessionConfiguration.background(withIdentifier: sessionTask.sessionIdentifier)
-//                        let backgroundSession = URLSession(
-//                                configuration: backgroundConfigObject,
-//                                delegate: self as URLSessionDelegate,
-//                                delegateQueue: nil)
-                    
-                        print("Rejoining session ", backgroundSession)
-                        scheduleBackgroundUpdate()
-                        if #available(watchOSApplicationExtension 4.0, *) {
-                            sessionTask.setTaskCompletedWithSnapshot(true)
-                        } else {
-                            // Fallback on earlier versions
-                            sessionTask.setTaskCompleted()
-                        }
-                    default:
-                        print("Ignoring task \(task)")
-                        // make sure to complete all tasks, even ones you don't handle
-                        task.setTaskCompleted()
-                }
+        // only handle these while running in the background
+        guard WKExtension.shared().applicationState == .background else {
+            backgroundTasks.forEach { $0.setTaskCompleted() }
+            return
+        }
+        
+        for task in backgroundTasks {
+            if let watchConnectivityBackgroundTask = task as? WKWatchConnectivityRefreshBackgroundTask {
+                handleWatchConnectivityBackgroundTask(watchConnectivityBackgroundTask)
+            } else if let snapshotTask = task as? WKSnapshotRefreshBackgroundTask {
+                handleSnapshotTask(snapshotTask)
+            } else if let sessionTask = task as? WKURLSessionRefreshBackgroundTask {
+                handleSessionTask(sessionTask)
+            } else if let refreshTask = task as? WKApplicationRefreshBackgroundTask {
+                handleRefreshTask(refreshTask)
+            } else {
+//                // not handled!
+//                task.setTaskCompleted()
+                
+                // do a refresh
+                handleRefreshTask(task)
             }
         }
+        
+        completeAllTasksIfReady()
     }
     
     @available(watchOSApplicationExtension 3.0, *)
-    fileprivate func scheduleBackgroundUpdate() {
+    func completeAllTasksIfReady() {
         
-        print("Schedule Background Update...\n")
+        guard let session = self.session else {
+            return
+        }
+        
+        // the session's properties only have valid values if the session is activated, so check that first
+        if session.activationState == .activated && !session.hasContentPending {
+            watchConnectivityBackgroundTasks.forEach { ($0 as! WKWatchConnectivityRefreshBackgroundTask).setTaskCompleted() }
+            watchConnectivityBackgroundTasks.removeAll()
+        }
+    }
+}
+
+extension ExtensionDelegate {
+    
+    // MARK:- Background update methods
+    
+    @available(watchOSApplicationExtension 3.0, *)
+    func handleWatchConnectivityBackgroundTask (_ watchConnectivityBackgroundTask: WKWatchConnectivityRefreshBackgroundTask) {
+        self.watchConnectivityBackgroundTasks.append(watchConnectivityBackgroundTask)
+    }
+    
+    @available(watchOSApplicationExtension 3.0, *)
+    func handleSnapshotTask(_ snapshotTask : WKSnapshotRefreshBackgroundTask) {
+        
+        // implement this if needed...
+        
+        snapshotTask.setTaskCompleted(restoredDefaultState: true, estimatedSnapshotExpiration: Date.distantFuture, userInfo: nil)
+    }
+    
+    @available(watchOSApplicationExtension 3.0, *)
+    func handleRefreshTask(_ task : WKRefreshBackgroundTask) {
+        
+        print("WKApplicationRefreshBackgroundTask received")
+        
+        // request data from phone app only if watch data is old (do not consume app's background refresh quota)
+        if NightscoutCacheService.singleton.getCurrentNightscoutData().isOlderThan5Minutes() {
+            requestNightscoutDataFromPhoneApp()
+        }
+        
+        // schedule the next background refresh
+        scheduleBackgroundRefresh()
+        
+        task.setTaskCompleted()
+    }
+    
+    @available(watchOSApplicationExtension 3.0, *)
+    func handleSessionTask(_ sessionTask: WKURLSessionRefreshBackgroundTask) {
+        
+        print("WKURLSessionRefreshTaskReceived, start URL session")
+        
+//        let backgroundSession = BackgroundUrlSessionWrapper.singleton
+//        let backgroundConfigObject = URLSessionConfiguration.background(withIdentifier: sessionTask.sessionIdentifier)
+//        let backgroundSession = URLSession(
+//            configuration: backgroundConfigObject,
+//            delegate: self as URLSessionDelegate,
+//            delegateQueue: nil)
+        
+        //                print("Rejoining session ", backgroundSession)
+        //                scheduleBackgroundUpdate()
+        //                if #available(watchOSApplicationExtension 4.0, *) {
+        //                    sessionTask.setTaskCompletedWithSnapshot(true)
+        //                } else {
+        //                    // Fallback on earlier versions
+        //                    sessionTask.setTaskCompleted()
+        //                }
+
+        sessionTask.setTaskCompleted()
+    }
+    
+    @discardableResult
+    func handleNightscoutDataMessage(_ message: [String: Any]) -> Bool {
+        
+        ndUpdates += 1
+        guard let data = message["nightscoutData"] as? Data, let nightscoutData = try? JSONDecoder().decode(NightscoutData.self, from: data) else {
+            print("Invalid nightscout data received from phone app!")
+            return false
+        }
+        
+        // check the data that already exists on the watch... maybe is newer that the received data
+        let currentNightscoutData = NightscoutCacheService.singleton.getCurrentNightscoutData()
+        if currentNightscoutData.time.doubleValue > nightscoutData.time.doubleValue {
+            
+            // Old data was received from phone app! This can happen because the watch can have newer data than the phone app (phone app background fetch is once in 5 minutes) or because the delivery is not instantaneous and ... and the watch can update its data in between (when the app enters foreground)
+            print("Received older nightscout data from phone app than watch has!")
+            ndOldUpdateData += 1
+            return false
+        } else if currentNightscoutData.time.doubleValue == nightscoutData.time.doubleValue {
+            // already have this data...
+            return true
+        }
+        
+        print("Nightscout data was received from phone app!")
+        NightscoutCacheService.singleton.updateCurrentNightscoutData(newNightscoutData: nightscoutData)
+        ndUpdatesSucceded += 1
+        updateComplication()
+        return true
+    }
+    
+    // MARK:- Internals
+    
+    @available(watchOSApplicationExtension 3.0, *)
+    fileprivate func scheduleBackgroundRefresh() {
+        
+        print("Schedule Background Refresh...\n")
         
         // Schedule a new refresh task in 15 Minutes (only 50 Updates are guaranteed from watchos per day :-/
         WKExtension.shared().scheduleBackgroundRefresh(withPreferredDate: Date(timeIntervalSinceNow: 60 * 15), userInfo: nil) { (error: Error?) in
@@ -109,7 +225,40 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate, URLSessionDelegate {
             }
         }
     }
+    
+    fileprivate func requestNightscoutDataFromPhoneApp() {
         
+        guard let session = self.session, session.isReachable else {
+            print("Session is not reachable... cannot request nightscout data from phone app...")
+            return
+        }
+        
+        ndRequests += 1
+        session.sendMessage(
+            ["requestNightscoutData": ""],
+            replyHandler: { [weak self] response in
+                if self?.handleNightscoutDataMessage(response) == true {
+                    self?.ndResponses += 1
+                    self?.updateComplication()
+                }
+            },
+            errorHandler: { [weak self] error in
+                print(error)
+                self?.ndRequestErrorMessages.append(error.localizedDescription)
+        })
+    }
+    
+    fileprivate func updateComplication() {
+        
+        let complicationServer = CLKComplicationServer.sharedInstance()
+        for complication in complicationServer.activeComplications ?? [] {
+            complicationServer.reloadTimeline(for: complication)
+        }
+    }
+}
+
+extension ExtensionDelegate: URLSessionDelegate {
+    
     public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         print("Background download was finished.")
         
@@ -123,12 +272,5 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate, URLSessionDelegate {
             NightscoutCacheService.singleton.updateCurrentNightscoutData(newNightscoutData: newNightscoutData)
             self.updateComplication()
         })
-    }
-    
-    fileprivate func updateComplication() {
-        let complicationServer = CLKComplicationServer.sharedInstance()
-        for complication in complicationServer.activeComplications! {
-            complicationServer.reloadTimeline(for: complication)
-        }
     }
 }

--- a/nightguard WatchKit Extension/ExtensionDelegate.swift
+++ b/nightguard WatchKit Extension/ExtensionDelegate.swift
@@ -59,13 +59,16 @@ extension InterfaceController: WKExtensionDelegate {
         }
         
         for task in backgroundTasks {
+            
+            // crash solving trick: acces the task user info to avoid a rare, but weird crash.. (https://forums.developer.apple.com/thread/96504 and https://stackoverflow.com/questions/46464660/wkrefreshbackgroundtask-cleanupstorage-error-attempting-to-reach-file)
+            userInfoAccess = task.userInfo
+            
             if let watchConnectivityBackgroundTask = task as? WKWatchConnectivityRefreshBackgroundTask {
                 handleWatchConnectivityBackgroundTask(watchConnectivityBackgroundTask)
             } else if let snapshotTask = task as? WKSnapshotRefreshBackgroundTask {
                 handleSnapshotTask(snapshotTask)
             } else if let sessionTask = task as? WKURLSessionRefreshBackgroundTask {
                 handleURLSessionTask(sessionTask)
-//                return
             } else if let refreshTask = task as? WKApplicationRefreshBackgroundTask {
                 handleRefreshTask(refreshTask)
             } else {
@@ -254,7 +257,7 @@ extension InterfaceController: URLSessionDownloadDelegate {
             })
         }
         
-        completePendingURLSessionTask()
+//        completePendingURLSessionTask()
     }
     
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
@@ -262,7 +265,7 @@ extension InterfaceController: URLSessionDownloadDelegate {
         if let error = error {
             BackgroundRefreshLogger.info("URL session did complete with error: \(error)")
         }
-        completePendingURLSessionTask()
+//        completePendingURLSessionTask()
     }
     
     func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {

--- a/nightguard WatchKit Extension/ExtensionDelegate.swift
+++ b/nightguard WatchKit Extension/ExtensionDelegate.swift
@@ -262,6 +262,11 @@ extension ExtensionDelegate {
             return
         }
         
+//        if self.backgroundSession != nil {
+//            BackgroundRefreshLogger.info("URL session still exists, we'll kill it and start a new one!")
+//            completePendingURLSessionTask()
+//        }
+        
         guard let (backgroundSession, downloadTask) = scheduleURLSession() else {
             BackgroundRefreshLogger.info("URL session cannot be created, probably base uri is not configured!")
             return

--- a/nightguard WatchKit Extension/Info.plist
+++ b/nightguard WatchKit Extension/Info.plist
@@ -49,6 +49,8 @@
 	</dict>
 	<key>RemoteInterfacePrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).InterfaceController</string>
+	<key>ShowLogsFromBackgroundRefreshTasks</key>
+	<true/>
 	<key>WKExtensionDelegateClassName</key>
 	<string>$(PRODUCT_MODULE_NAME).ExtensionDelegate</string>
 </dict>

--- a/nightguard WatchKit Extension/Info.plist
+++ b/nightguard WatchKit Extension/Info.plist
@@ -49,8 +49,6 @@
 	</dict>
 	<key>RemoteInterfacePrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).InterfaceController</string>
-	<key>ShowLogsFromBackgroundRefreshTasks</key>
-	<true/>
 	<key>WKExtensionDelegateClassName</key>
 	<string>$(PRODUCT_MODULE_NAME).ExtensionDelegate</string>
 </dict>

--- a/nightguard WatchKit Extension/InfoInterfaceController.swift
+++ b/nightguard WatchKit Extension/InfoInterfaceController.swift
@@ -52,6 +52,9 @@ class InfoInterfaceController: WKInterfaceController {
                 text += "\nBackground refreshes (background URL session started): \(ext.backgroundURLSessions)"
                 text += "\nNew data: \(ext.backgroundURLSessionUpdatesWithNewData), existing: \(ext.backgroundURLSessionUpdatesWithSameData), old: \(ext.backgroundURLSessionUpdatesWithOldData)\n"
                 
+                text += "\nBackground tasks log:\n"
+                text += ext.backgroundTasksLog.joined(separator: "\n")
+                
                 //            if !ext.ndRequestErrorMessages.isEmpty {
                 //                text += "Request errors: \n" + ext.ndRequestErrorMessages.joined(separator: "\n")
                 //            }

--- a/nightguard WatchKit Extension/InfoInterfaceController.swift
+++ b/nightguard WatchKit Extension/InfoInterfaceController.swift
@@ -14,6 +14,7 @@ class InfoInterfaceController: WKInterfaceController {
     @IBOutlet var versionLabel: WKInterfaceLabel!
     @IBOutlet var serverUriLabel: WKInterfaceLabel!
     @IBOutlet var cachedValuesLabel: WKInterfaceLabel!
+    @IBOutlet var backgroundUpdatesLabel: WKInterfaceLabel!
     
     @IBAction func doCloseAction() {
         self.dismiss()
@@ -24,20 +25,37 @@ class InfoInterfaceController: WKInterfaceController {
         // This method is called when watch view controller is about to be visible to user
         super.willActivate()
         
-        displayTheApplicationVersionNumber()
-        serverUriLabel.setText(UserDefaultsRepository.readBaseUri())
+        displayLabels()
     }
     
-    func displayTheApplicationVersionNumber() {
+    func displayLabels() {
         
+        serverUriLabel.setText(UserDefaultsRepository.readBaseUri())
+        
+        // version number
         let versionNumber: String = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
         let buildNumber: String = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as! String
-        
         versionLabel.setText("V\(versionNumber).\(buildNumber)")
         
+        // cached values
         let todaysBgData = NightscoutDataRepository.singleton.loadTodaysBgData()
         let yesterdaysBgData = NightscoutDataRepository.singleton.loadYesterdaysBgData()
-        
         cachedValuesLabel.setText("\(todaysBgData.count) / \(yesterdaysBgData.count)")
+        
+        // background updates
+        if let ext = WKExtension.shared().delegate as? ExtensionDelegate {
+            
+            var text = "Total updates: \(ext.ndUpdatesSucceded)/\(ext.ndUpdates) from which: \n-background refresh (request phone data): \(ext.ndResponses)/\(ext.ndRequests)\n-all the rest are phone initiated complication updates"
+            
+            if ext.ndOldUpdateData > 0 {
+                text += "\n\n\(ext.ndOldUpdateData) updates with older data than current watch data."
+            }
+            
+            if !ext.ndRequestErrorMessages.isEmpty {
+                text += "Request errors: \n" + ext.ndRequestErrorMessages.joined(separator: "\n")
+            }
+            
+            backgroundUpdatesLabel.setText(text)
+        }
     }
 }

--- a/nightguard WatchKit Extension/InfoInterfaceController.swift
+++ b/nightguard WatchKit Extension/InfoInterfaceController.swift
@@ -43,27 +43,14 @@ class InfoInterfaceController: WKInterfaceController {
         cachedValuesLabel.setText("\(todaysBgData.count) / \(yesterdaysBgData.count)")
         
         // background updates
-        if #available(watchOSApplicationExtension 3.0, *) {
-            if let ext = WKExtension.shared().rootInterfaceController as? InterfaceController {
-                
-                var text = "Complication updates (initiated from phone app): \(ext.phoneUpdates)"
-                text += "\nNew data: \(ext.phoneUpdatesWithNewData), existing: \(ext.phoneUpdatesWithSameData), old: \(ext.phoneUpdatesWithOldData)\n"
-                
-                text += "\nBackground refreshes (background URL session started): \(ext.backgroundURLSessions)"
-                text += "\nNew data: \(ext.backgroundURLSessionUpdatesWithNewData), existing: \(ext.backgroundURLSessionUpdatesWithSameData), old: \(ext.backgroundURLSessionUpdatesWithOldData)\n"
-                
-                text += "\nBackground tasks log:\n"
-                text += ext.backgroundTasksLog.joined(separator: "\n")
-                
-                //            if !ext.ndRequestErrorMessages.isEmpty {
-                //                text += "Request errors: \n" + ext.ndRequestErrorMessages.joined(separator: "\n")
-                //            }
-                
-                backgroundUpdatesLabel.setText(text)
-            }
-        } else {
-            // Fallback on earlier versions
-            backgroundUpdatesLabel.setText("NO")
-        }
+        var text = "Complication updates (initiated from phone app): \(BackgroundRefreshLogger.phoneUpdates)"
+        text += "\nNew data: \(BackgroundRefreshLogger.phoneUpdatesWithNewData), existing: \(BackgroundRefreshLogger.phoneUpdatesWithSameData), old: \(BackgroundRefreshLogger.phoneUpdatesWithOldData)\n"
+        
+        text += "\nBackground refreshes (background URL session started): \(BackgroundRefreshLogger.backgroundURLSessions)"
+        text += "\nNew data: \(BackgroundRefreshLogger.backgroundURLSessionUpdatesWithNewData), existing: \(BackgroundRefreshLogger.backgroundURLSessionUpdatesWithSameData), old: \(BackgroundRefreshLogger.backgroundURLSessionUpdatesWithOldData)\n"
+        
+        text += "\nBackground tasks log:\n"
+        text += BackgroundRefreshLogger.logs.joined(separator: "\n")
+        backgroundUpdatesLabel.setText(text)
     }
 }

--- a/nightguard WatchKit Extension/InfoInterfaceController.swift
+++ b/nightguard WatchKit Extension/InfoInterfaceController.swift
@@ -47,11 +47,13 @@ class InfoInterfaceController: WKInterfaceController {
             
             var text = "Complication updates (initiated from phone app): \(ext.successfullPhoneUpdates)/\(ext.phoneUpdates)"
             if ext.phoneUpdatesWithOldData > 0 {
-                text += "\n\(ext.phoneUpdatesWithOldData) updates had older data than current watch data."
+                text += "\n\(ext.phoneUpdatesWithOldData) phone app updates had older data than current watch data."
             }
             
             text += "\n\nBackground refreshes: \(ext.successfulBackgroundURLSessions)/\(ext.backgroundURLSessions)"
-            
+            if ext.backgroundURLSessionUpdatesWithOldData > 0 {
+                text += "\n\(ext.backgroundURLSessionUpdatesWithOldData) URL session updates had older data than current watch data."
+            }
             
 //            if !ext.ndRequestErrorMessages.isEmpty {
 //                text += "Request errors: \n" + ext.ndRequestErrorMessages.joined(separator: "\n")

--- a/nightguard WatchKit Extension/InfoInterfaceController.swift
+++ b/nightguard WatchKit Extension/InfoInterfaceController.swift
@@ -43,13 +43,19 @@ class InfoInterfaceController: WKInterfaceController {
         cachedValuesLabel.setText("\(todaysBgData.count) / \(yesterdaysBgData.count)")
         
         // background updates
-        var text = "Complication updates (initiated from phone app): \(BackgroundRefreshLogger.phoneUpdates)"
+        var text = "📱Updates initiated by phone app: \(BackgroundRefreshLogger.phoneUpdates)"
         text += "\nNew data: \(BackgroundRefreshLogger.phoneUpdatesWithNewData), existing: \(BackgroundRefreshLogger.phoneUpdatesWithSameData), old: \(BackgroundRefreshLogger.phoneUpdatesWithOldData)\n"
         
-        text += "\nBackground refreshes: \(BackgroundRefreshLogger.backgroundRefreshes) (\(BackgroundRefreshLogger.formattedBackgroundRefreshesPerHour) per hour)"
+        text += "\n⌚Background updates: \(BackgroundRefreshLogger.backgroundRefreshes) (\(BackgroundRefreshLogger.formattedBackgroundRefreshesPerHour) per hour)"
         text += "\nBackground URL sessions: \(BackgroundRefreshLogger.backgroundURLSessions) (\(BackgroundRefreshLogger.formattedBackgroundRefreshesStartingURLSessions))"
         
         text += "\nNew data: \(BackgroundRefreshLogger.backgroundURLSessionUpdatesWithNewData), existing: \(BackgroundRefreshLogger.backgroundURLSessionUpdatesWithSameData), old: \(BackgroundRefreshLogger.backgroundURLSessionUpdatesWithOldData)\n"
+        
+        if !BackgroundRefreshLogger.receivedData.isEmpty {
+            text += "\nReceived data:\n"
+            text += BackgroundRefreshLogger.receivedData.joined(separator: "\n")
+            text += "\n"
+        }
         
         if !BackgroundRefreshLogger.logs.isEmpty {
             text += "\nLogs from background tasks:\n"

--- a/nightguard WatchKit Extension/InfoInterfaceController.swift
+++ b/nightguard WatchKit Extension/InfoInterfaceController.swift
@@ -46,7 +46,9 @@ class InfoInterfaceController: WKInterfaceController {
         var text = "Complication updates (initiated from phone app): \(BackgroundRefreshLogger.phoneUpdates)"
         text += "\nNew data: \(BackgroundRefreshLogger.phoneUpdatesWithNewData), existing: \(BackgroundRefreshLogger.phoneUpdatesWithSameData), old: \(BackgroundRefreshLogger.phoneUpdatesWithOldData)\n"
         
-        text += "\nBackground refreshes (background URL session started): \(BackgroundRefreshLogger.backgroundURLSessions)"
+        text += "\nBackground refreshes: \(BackgroundRefreshLogger.backgroundRefreshes) (\(BackgroundRefreshLogger.formattedBackgroundRefreshesPerHour) per hour)"
+        text += "\nBackground URL sessions: \(BackgroundRefreshLogger.backgroundURLSessions) (\(BackgroundRefreshLogger.formattedBackgroundRefreshesStartingURLSessions))"
+        
         text += "\nNew data: \(BackgroundRefreshLogger.backgroundURLSessionUpdatesWithNewData), existing: \(BackgroundRefreshLogger.backgroundURLSessionUpdatesWithSameData), old: \(BackgroundRefreshLogger.backgroundURLSessionUpdatesWithOldData)\n"
         
         text += "\nBackground tasks log:\n"

--- a/nightguard WatchKit Extension/InfoInterfaceController.swift
+++ b/nightguard WatchKit Extension/InfoInterfaceController.swift
@@ -45,15 +45,17 @@ class InfoInterfaceController: WKInterfaceController {
         // background updates
         if let ext = WKExtension.shared().delegate as? ExtensionDelegate {
             
-            var text = "Total updates: \(ext.ndUpdatesSucceded)/\(ext.ndUpdates) from which: \n-background refresh (request phone data): \(ext.ndResponses)/\(ext.ndRequests)\n-all the rest are phone initiated complication updates"
-            
-            if ext.ndOldUpdateData > 0 {
-                text += "\n\n\(ext.ndOldUpdateData) updates with older data than current watch data."
+            var text = "Complication updates (initiated from phone app): \(ext.successfullPhoneUpdates)/\(ext.phoneUpdates)"
+            if ext.phoneUpdatesWithOldData > 0 {
+                text += "\n\(ext.phoneUpdatesWithOldData) updates had older data than current watch data."
             }
             
-            if !ext.ndRequestErrorMessages.isEmpty {
-                text += "Request errors: \n" + ext.ndRequestErrorMessages.joined(separator: "\n")
-            }
+            text += "\n\nBackground refreshes: \(ext.successfulBackgroundURLSessions)/\(ext.backgroundURLSessions)"
+            
+            
+//            if !ext.ndRequestErrorMessages.isEmpty {
+//                text += "Request errors: \n" + ext.ndRequestErrorMessages.joined(separator: "\n")
+//            }
             
             backgroundUpdatesLabel.setText(text)
         }

--- a/nightguard WatchKit Extension/InfoInterfaceController.swift
+++ b/nightguard WatchKit Extension/InfoInterfaceController.swift
@@ -51,8 +51,11 @@ class InfoInterfaceController: WKInterfaceController {
         
         text += "\nNew data: \(BackgroundRefreshLogger.backgroundURLSessionUpdatesWithNewData), existing: \(BackgroundRefreshLogger.backgroundURLSessionUpdatesWithSameData), old: \(BackgroundRefreshLogger.backgroundURLSessionUpdatesWithOldData)\n"
         
-        text += "\nBackground tasks log:\n"
-        text += BackgroundRefreshLogger.logs.joined(separator: "\n")
+        if !BackgroundRefreshLogger.logs.isEmpty {
+            text += "\nLogs from background tasks:\n"
+            text += BackgroundRefreshLogger.logs.joined(separator: "\n")
+        }
+        
         backgroundUpdatesLabel.setText(text)
     }
 }

--- a/nightguard WatchKit Extension/InfoInterfaceController.swift
+++ b/nightguard WatchKit Extension/InfoInterfaceController.swift
@@ -43,23 +43,24 @@ class InfoInterfaceController: WKInterfaceController {
         cachedValuesLabel.setText("\(todaysBgData.count) / \(yesterdaysBgData.count)")
         
         // background updates
-        if let ext = WKExtension.shared().delegate as? ExtensionDelegate {
-            
-            var text = "Complication updates (initiated from phone app): \(ext.successfullPhoneUpdates)/\(ext.phoneUpdates)"
-            if ext.phoneUpdatesWithOldData > 0 {
-                text += "\n\(ext.phoneUpdatesWithOldData) phone app updates had older data than current watch data."
+        if #available(watchOSApplicationExtension 3.0, *) {
+            if let ext = WKExtension.shared().rootInterfaceController as? InterfaceController {
+                
+                var text = "Complication updates (initiated from phone app): \(ext.phoneUpdates)"
+                text += "\nNew data: \(ext.phoneUpdatesWithNewData), existing: \(ext.phoneUpdatesWithSameData), old: \(ext.phoneUpdatesWithOldData)\n"
+                
+                text += "\nBackground refreshes (background URL session started): \(ext.backgroundURLSessions)"
+                text += "\nNew data: \(ext.backgroundURLSessionUpdatesWithNewData), existing: \(ext.backgroundURLSessionUpdatesWithSameData), old: \(ext.backgroundURLSessionUpdatesWithOldData)\n"
+                
+                //            if !ext.ndRequestErrorMessages.isEmpty {
+                //                text += "Request errors: \n" + ext.ndRequestErrorMessages.joined(separator: "\n")
+                //            }
+                
+                backgroundUpdatesLabel.setText(text)
             }
-            
-            text += "\n\nBackground refreshes: \(ext.successfulBackgroundURLSessions)/\(ext.backgroundURLSessions)"
-            if ext.backgroundURLSessionUpdatesWithOldData > 0 {
-                text += "\n\(ext.backgroundURLSessionUpdatesWithOldData) URL session updates had older data than current watch data."
-            }
-            
-//            if !ext.ndRequestErrorMessages.isEmpty {
-//                text += "Request errors: \n" + ext.ndRequestErrorMessages.joined(separator: "\n")
-//            }
-            
-            backgroundUpdatesLabel.setText(text)
+        } else {
+            // Fallback on earlier versions
+            backgroundUpdatesLabel.setText("NO")
         }
     }
 }

--- a/nightguard WatchKit Extension/InterfaceController.swift
+++ b/nightguard WatchKit Extension/InterfaceController.swift
@@ -58,8 +58,10 @@ class InterfaceController: WKInterfaceController, WKCrownDelegate {
     var watchConnectivityBackgroundTasks: [Any] = []
     var pendingBackgroundURLTask: Any?
     var backgroundSession: URLSession?
+    var downloadTask: URLSessionDownloadTask?
     
     // debugging info (stats) for background refresh
+    var nextBackgroundRefreshTime: Date?
     var backgroundURLSessions: Int = 0
     var backgroundURLSessionUpdatesWithNewData: Int = 0
     var backgroundURLSessionUpdatesWithSameData: Int = 0
@@ -68,6 +70,7 @@ class InterfaceController: WKInterfaceController, WKCrownDelegate {
     var phoneUpdatesWithNewData: Int = 0
     var phoneUpdatesWithSameData: Int = 0
     var phoneUpdatesWithOldData: Int = 0
+    var backgroundTasksLog: [String] = []
     
     override func awake(withContext context: Any?) {
         super.awake(withContext: context)

--- a/nightguard WatchKit Extension/InterfaceController.swift
+++ b/nightguard WatchKit Extension/InterfaceController.swift
@@ -42,35 +42,21 @@ class InterfaceController: WKInterfaceController, WKCrownDelegate {
     fileprivate var isActive: Bool = false
     
     
+    /////////////////////////////////////////////////////////////
+    // WKExtensionDelegate data (the WKExtensionDelegate protocol was implemented by InterfaceController -  https://stackoverflow.com/questions/41156386/wkurlsessionrefreshbackgroundtask-isnt-called-when-attempting-to-do-background)
     var session: WCSession? {
         didSet {
             if let session = session {
                 session.delegate = AppMessageService.singleton
                 session.activate()
-                
-                // https://developer.apple.com/library/content/samplecode/QuickSwitch/Listings/QuickSwitch_WatchKit_Extension_ExtensionDelegate_swift.html
-                session.addObserver(self, forKeyPath: "activationState", options: [], context: nil)
-                session.addObserver(self, forKeyPath: "hasContentPending", options: [], context: nil)
             }
         }
     }
     
-    var watchConnectivityBackgroundTasks: [Any] = []
     var pendingBackgroundURLTask: Any?
     var backgroundSession: URLSession?
     var downloadTask: URLSessionDownloadTask?
-    
-    // debugging info (stats) for background refresh
-    var nextBackgroundRefreshTime: Date?
-    var backgroundURLSessions: Int = 0
-    var backgroundURLSessionUpdatesWithNewData: Int = 0
-    var backgroundURLSessionUpdatesWithSameData: Int = 0
-    var backgroundURLSessionUpdatesWithOldData: Int = 0
-    var phoneUpdates: Int = 0
-    var phoneUpdatesWithNewData: Int = 0
-    var phoneUpdatesWithSameData: Int = 0
-    var phoneUpdatesWithOldData: Int = 0
-    var backgroundTasksLog: [String] = []
+    /////////////////////////////////////////////////////////////
     
     override func awake(withContext context: Any?) {
         super.awake(withContext: context)
@@ -86,8 +72,10 @@ class InterfaceController: WKInterfaceController, WKCrownDelegate {
         
         createMenuItems()
         
-        // Configure interface objects here.
+        // the trick: make myself the WKExtensionDelegate (https://stackoverflow.com/questions/41156386/wkurlsessionrefreshbackgroundtask-isnt-called-when-attempting-to-do-background)
         WKExtension.shared().delegate = self
+        // and one more: we have to manually call this protocol method (just this), the framework will not call it for us anymore (probably because we changed the delegate instance...)
+        applicationDidFinishLaunching()
     }
     
     fileprivate func determineSceneHeightFromCurrentWatchType(interfaceBounds : CGRect) -> CGFloat {

--- a/nightguard WatchKit Extension/InterfaceController.swift
+++ b/nightguard WatchKit Extension/InterfaceController.swift
@@ -56,6 +56,7 @@ class InterfaceController: WKInterfaceController, WKCrownDelegate {
     var pendingBackgroundURLTask: Any?
     var backgroundSession: URLSession?
     var downloadTask: URLSessionDownloadTask?
+    var userInfoAccess: NSSecureCoding?
     /////////////////////////////////////////////////////////////
     
     override func awake(withContext context: Any?) {

--- a/nightguard WatchKit Extension/InterfaceController.swift
+++ b/nightguard WatchKit Extension/InterfaceController.swift
@@ -42,24 +42,6 @@ class InterfaceController: WKInterfaceController, WKCrownDelegate {
     fileprivate var isActive: Bool = false
     fileprivate var isFirstActivation: Bool = true
     
-    /////////////////////////////////////////////////////////////
-    // WKExtensionDelegate data (the WKExtensionDelegate protocol was implemented by InterfaceController -  https://stackoverflow.com/questions/41156386/wkurlsessionrefreshbackgroundtask-isnt-called-when-attempting-to-do-background)
-    var session: WCSession? {
-        didSet {
-            if let session = session {
-                session.delegate = AppMessageService.singleton
-                session.activate()
-            }
-        }
-    }
-    
-    var pendingBackgroundURLTask: Any?
-    var backgroundSession: URLSession?
-    var downloadTask: URLSessionDownloadTask?
-    var sessionError: Error?
-    var userInfoAccess: NSSecureCoding?
-    /////////////////////////////////////////////////////////////
-    
     override func awake(withContext context: Any?) {
         super.awake(withContext: context)
         
@@ -73,11 +55,6 @@ class InterfaceController: WKInterfaceController, WKCrownDelegate {
         errorGroup.setHidden(true)
         
         createMenuItems()
-        
-        // the trick: make myself the WKExtensionDelegate (https://stackoverflow.com/questions/41156386/wkurlsessionrefreshbackgroundtask-isnt-called-when-attempting-to-do-background)
-        WKExtension.shared().delegate = self
-        // and one more: we have to manually call this protocol method (just this), the framework will not call it for us anymore (probably because we changed the delegate instance...)
-        applicationDidFinishLaunching()
     }
     
     fileprivate func determineSceneHeightFromCurrentWatchType(interfaceBounds : CGRect) -> CGFloat {

--- a/nightguard WatchKit Extension/InterfaceController.swift
+++ b/nightguard WatchKit Extension/InterfaceController.swift
@@ -78,8 +78,13 @@ class InterfaceController: WKInterfaceController, WKCrownDelegate {
         // if the user keeps the display active for a longer time
         createNewTimerSingleton()
         
-        // manually refresh the gui by fireing the timer
-        timerDidEnd(timer)
+        // manually refresh the gui by fireing the timer (if we have old data!)
+        let currentNightscoutData = NightscoutCacheService.singleton.getCurrentNightscoutData()
+        if currentNightscoutData.isOlderThan5Minutes() {
+            timerDidEnd(timer)
+        } else {
+            paintCurrentBgData(currentNightscoutData: currentNightscoutData)
+        }
         
         // Ask to get 8 minutes of cpu runtime to get the next values if
         // the app stays in frontmost state

--- a/nightguard WatchKit Extension/InterfaceController.swift
+++ b/nightguard WatchKit Extension/InterfaceController.swift
@@ -40,7 +40,7 @@ class InterfaceController: WKInterfaceController, WKCrownDelegate {
     fileprivate var cachedYesterdaysBgValues : [BloodSugar] = []
     
     fileprivate var isActive: Bool = false
-    
+    fileprivate var isFirstActivation: Bool = true    
     
     /////////////////////////////////////////////////////////////
     // WKExtensionDelegate data (the WKExtensionDelegate protocol was implemented by InterfaceController -  https://stackoverflow.com/questions/41156386/wkurlsessionrefreshbackgroundtask-isnt-called-when-attempting-to-do-background)
@@ -106,13 +106,17 @@ class InterfaceController: WKInterfaceController, WKCrownDelegate {
         // if the user keeps the display active for a longer time
         createNewTimerSingleton()
         
-        // manually refresh the gui by fireing the timer (if we have old data!)
-//        let currentNightscoutData = NightscoutCacheService.singleton.getCurrentNightscoutData()
-//        if currentNightscoutData.isOlderThan5Minutes() {
+        // check if we have old nightscout data...
+        let currentNightscoutData = NightscoutCacheService.singleton.getCurrentNightscoutData()
+        if isFirstActivation || currentNightscoutData.isOlderThan5Minutes() {
+            
+            // if yes, manually refresh the gui by fireing the timer
             timerDidEnd(timer)
-//        } else {
-//            paintCurrentBgData(currentNightscoutData: currentNightscoutData)
-//        }
+        } else {
+            
+            // otwherwise just update the gui with current data (will update the time, etc., but will not display the activity indicator & error panel)
+            updateInterface(withNightscoutData: currentNightscoutData, error: nil)
+        }
         
         // Ask to get 8 minutes of cpu runtime to get the next values if
         // the app stays in frontmost state
@@ -124,6 +128,9 @@ class InterfaceController: WKInterfaceController, WKCrownDelegate {
         crownSequencer.delegate = self
         
         paintChartData(todaysData: cachedTodaysBgValues, yesterdaysData: cachedYesterdaysBgValues, moveToLatestValue: false)
+        
+        // reset the first activation flag!
+        isFirstActivation = false
     }
     
     override func didAppear() {

--- a/nightguard WatchKit Extension/InterfaceController.swift
+++ b/nightguard WatchKit Extension/InterfaceController.swift
@@ -40,7 +40,7 @@ class InterfaceController: WKInterfaceController, WKCrownDelegate {
     fileprivate var cachedYesterdaysBgValues : [BloodSugar] = []
     
     fileprivate var isActive: Bool = false
-    fileprivate var isFirstActivation: Bool = true    
+    fileprivate var isFirstActivation: Bool = true
     
     /////////////////////////////////////////////////////////////
     // WKExtensionDelegate data (the WKExtensionDelegate protocol was implemented by InterfaceController -  https://stackoverflow.com/questions/41156386/wkurlsessionrefreshbackgroundtask-isnt-called-when-attempting-to-do-background)

--- a/nightguard.xcodeproj/project.pbxproj
+++ b/nightguard.xcodeproj/project.pbxproj
@@ -94,6 +94,8 @@
 		43F1E1111D076C1C00C329A2 /* NightscoutService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F1E1101D076C1C00C329A2 /* NightscoutService.swift */; };
 		43F1E1121D076C4500C329A2 /* NightscoutService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F1E1101D076C1C00C329A2 /* NightscoutService.swift */; };
 		43F1E11B1D076D9700C329A2 /* TimeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F1E11A1D076D9700C329A2 /* TimeService.swift */; };
+		D10ACE402063C25600F41EE7 /* BackgroundRefreshSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10ACE3F2063C25600F41EE7 /* BackgroundRefreshSettings.swift */; };
+		D10ACE412063C2A300F41EE7 /* BackgroundRefreshSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10ACE3F2063C25600F41EE7 /* BackgroundRefreshSettings.swift */; };
 		D1BD14E5205BB9E200B93389 /* BackgroundRefreshScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1BD14E4205BB9E200B93389 /* BackgroundRefreshScheduler.swift */; };
 		D1BD14E7205BCCF200B93389 /* BackgroundRefreshLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1BD14E6205BCCF200B93389 /* BackgroundRefreshLogger.swift */; };
 /* End PBXBuildFile section */
@@ -220,6 +222,7 @@
 		43F1E0FC1D07698000C329A2 /* scoutwatch.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = scoutwatch.entitlements; path = nightguard/scoutwatch.entitlements; sourceTree = SOURCE_ROOT; };
 		43F1E1101D076C1C00C329A2 /* NightscoutService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NightscoutService.swift; path = nightguard/NightscoutService.swift; sourceTree = SOURCE_ROOT; };
 		43F1E11A1D076D9700C329A2 /* TimeService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TimeService.swift; path = nightguard/TimeService.swift; sourceTree = SOURCE_ROOT; };
+		D10ACE3F2063C25600F41EE7 /* BackgroundRefreshSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundRefreshSettings.swift; sourceTree = "<group>"; };
 		D1BD14E4205BB9E200B93389 /* BackgroundRefreshScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundRefreshScheduler.swift; sourceTree = "<group>"; };
 		D1BD14E6205BCCF200B93389 /* BackgroundRefreshLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundRefreshLogger.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -287,6 +290,7 @@
 				43119B861C383CF500DD6D35 /* UIColorChanger.swift */,
 				D1BD14E4205BB9E200B93389 /* BackgroundRefreshScheduler.swift */,
 				D1BD14E6205BCCF200B93389 /* BackgroundRefreshLogger.swift */,
+				D10ACE3F2063C25600F41EE7 /* BackgroundRefreshSettings.swift */,
 			);
 			name = app;
 			sourceTree = "<group>";
@@ -702,6 +706,7 @@
 				43288A6C1D1C893200EE3999 /* TabBarController.swift in Sources */,
 				43F1E1081D07698000C329A2 /* PrefsViewController.swift in Sources */,
 				43F1E1071D07698000C329A2 /* NightscoutData.swift in Sources */,
+				D10ACE412063C2A300F41EE7 /* BackgroundRefreshSettings.swift in Sources */,
 				4351E6AE1D2ADFBE001E4AE4 /* StatsPrefsViewController.swift in Sources */,
 				43119B811C382A0E00DD6D35 /* AppConstants.swift in Sources */,
 				43F1E0EE1D07693300C329A2 /* AlarmRule.swift in Sources */,
@@ -750,6 +755,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D10ACE402063C25600F41EE7 /* BackgroundRefreshSettings.swift in Sources */,
 				4346F9841D0773F700487541 /* TimeService.swift in Sources */,
 				D1BD14E7205BCCF200B93389 /* BackgroundRefreshLogger.swift in Sources */,
 				43E89E5C1E6A1D72005B0A65 /* ChartScene.swift in Sources */,

--- a/nightguard.xcodeproj/project.pbxproj
+++ b/nightguard.xcodeproj/project.pbxproj
@@ -94,6 +94,8 @@
 		43F1E1111D076C1C00C329A2 /* NightscoutService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F1E1101D076C1C00C329A2 /* NightscoutService.swift */; };
 		43F1E1121D076C4500C329A2 /* NightscoutService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F1E1101D076C1C00C329A2 /* NightscoutService.swift */; };
 		43F1E11B1D076D9700C329A2 /* TimeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43F1E11A1D076D9700C329A2 /* TimeService.swift */; };
+		D1BD14E5205BB9E200B93389 /* BackgroundRefreshScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1BD14E4205BB9E200B93389 /* BackgroundRefreshScheduler.swift */; };
+		D1BD14E7205BCCF200B93389 /* BackgroundRefreshLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1BD14E6205BCCF200B93389 /* BackgroundRefreshLogger.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -218,6 +220,8 @@
 		43F1E0FC1D07698000C329A2 /* scoutwatch.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = scoutwatch.entitlements; path = nightguard/scoutwatch.entitlements; sourceTree = SOURCE_ROOT; };
 		43F1E1101D076C1C00C329A2 /* NightscoutService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NightscoutService.swift; path = nightguard/NightscoutService.swift; sourceTree = SOURCE_ROOT; };
 		43F1E11A1D076D9700C329A2 /* TimeService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TimeService.swift; path = nightguard/TimeService.swift; sourceTree = SOURCE_ROOT; };
+		D1BD14E4205BB9E200B93389 /* BackgroundRefreshScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundRefreshScheduler.swift; sourceTree = "<group>"; };
+		D1BD14E6205BCCF200B93389 /* BackgroundRefreshLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundRefreshLogger.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -281,6 +285,8 @@
 			isa = PBXGroup;
 			children = (
 				43119B861C383CF500DD6D35 /* UIColorChanger.swift */,
+				D1BD14E4205BB9E200B93389 /* BackgroundRefreshScheduler.swift */,
+				D1BD14E6205BCCF200B93389 /* BackgroundRefreshLogger.swift */,
 			);
 			name = app;
 			sourceTree = "<group>";
@@ -745,6 +751,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4346F9841D0773F700487541 /* TimeService.swift in Sources */,
+				D1BD14E7205BCCF200B93389 /* BackgroundRefreshLogger.swift in Sources */,
 				43E89E5C1E6A1D72005B0A65 /* ChartScene.swift in Sources */,
 				439FCEB91FD5EC2F009D18FD /* BackgroundUrlSessionWrapper.swift in Sources */,
 				432E62EC1D15EFEC00DD7978 /* FloatExtension.swift in Sources */,
@@ -766,6 +773,7 @@
 				43288A681D1B359D00EE3999 /* StringExtension.swift in Sources */,
 				438066FE1D21C2350021B618 /* AppMessageService.swift in Sources */,
 				437EEDC51FB7185500694EAD /* UserDefaultsRepository.swift in Sources */,
+				D1BD14E5205BB9E200B93389 /* BackgroundRefreshScheduler.swift in Sources */,
 				43794F421C2F435A00DB8B58 /* AppConstants.swift in Sources */,
 				439C39181C0E002F00D89872 /* ChartPainter.swift in Sources */,
 			);

--- a/nightguard/AppDelegate.swift
+++ b/nightguard/AppDelegate.swift
@@ -118,7 +118,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 completionHandler(.failed)
             } else {
                 completionHandler(.newData)
-//                WatchService.singleton.updateWatchComplicationIfPossible()
+                WatchService.singleton.updateWatchComplicationIfPossible()
             }
         }
         

--- a/nightguard/AppDelegate.swift
+++ b/nightguard/AppDelegate.swift
@@ -118,6 +118,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 completionHandler(.failed)
             } else {
                 completionHandler(.newData)
+                WatchService.singleton.sendToWatchCurrentNightwatchData()
                 WatchService.singleton.updateWatchComplicationIfPossible()
             }
         }

--- a/nightguard/AppDelegate.swift
+++ b/nightguard/AppDelegate.swift
@@ -118,7 +118,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 completionHandler(.failed)
             } else {
                 completionHandler(.newData)
-                WatchService.singleton.updateWatchComplicationIfPossible()
+//                WatchService.singleton.updateWatchComplicationIfPossible()
             }
         }
         

--- a/nightguard/AppDelegate.swift
+++ b/nightguard/AppDelegate.swift
@@ -30,8 +30,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         UITabBar.appearance().tintColor = UIColor.white
         
-        // This application should be called in background every 5 Minutes
-        UIApplication.shared.setMinimumBackgroundFetchInterval(5 * 60)
+        // This application should be called in background every X Minutes
+        UIApplication.shared.setMinimumBackgroundFetchInterval(
+            TimeInterval(BackgroundRefreshSettings.backgroundFetchInterval * 60)
+        )
         
         activateWatchConnectivity()
         initializeApplicationDefaults()

--- a/nightguard/AppDelegate.swift
+++ b/nightguard/AppDelegate.swift
@@ -31,7 +31,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         UITabBar.appearance().tintColor = UIColor.white
         
         // This application should be called in background every 5 Minutes
-        UIApplication.shared.setMinimumBackgroundFetchInterval(5*60)
+        UIApplication.shared.setMinimumBackgroundFetchInterval(5 * 60)
         
         activateWatchConnectivity()
         initializeApplicationDefaults()
@@ -111,6 +111,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication,
         performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+        
+        WatchService.singleton.updateWatchComplicationIfPossible()
+        
+        // just refresh the current nightscout data
+        let _ = NightscoutCacheService.singleton.loadCurrentNightscoutData { _, error in
+            if let _ = error {
+                completionHandler(.failed)
+            } else {
+                completionHandler(.newData)
+            }
+        }
         
         // This can be used to alarm even when the app is in the background
         // but this doesn't work very well - so removed it so far...

--- a/nightguard/AppDelegate.swift
+++ b/nightguard/AppDelegate.swift
@@ -112,14 +112,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication,
         performFetchWithCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
         
-        WatchService.singleton.updateWatchComplicationIfPossible()
-        
         // just refresh the current nightscout data
         let _ = NightscoutCacheService.singleton.loadCurrentNightscoutData { _, error in
             if let _ = error {
                 completionHandler(.failed)
             } else {
                 completionHandler(.newData)
+                WatchService.singleton.updateWatchComplicationIfPossible()
             }
         }
         

--- a/nightguard/AppDelegate.swift
+++ b/nightguard/AppDelegate.swift
@@ -119,7 +119,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             } else {
                 completionHandler(.newData)
                 WatchService.singleton.sendToWatchCurrentNightwatchData()
-                WatchService.singleton.updateWatchComplicationIfPossible()
             }
         }
         

--- a/nightguard/AppDelegate.swift
+++ b/nightguard/AppDelegate.swift
@@ -117,8 +117,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             if let _ = error {
                 completionHandler(.failed)
             } else {
-                completionHandler(.newData)
                 WatchService.singleton.sendToWatchCurrentNightwatchData()
+                completionHandler(.newData)
             }
         }
         

--- a/nightguard/MainViewController.swift
+++ b/nightguard/MainViewController.swift
@@ -180,6 +180,8 @@ class MainViewController: UIViewController {
         // => in that case the user has to know that the values are old!
         loadAndPaintCurrentBgData()
         loadAndPaintChartData(forceRepaint: false)
+        
+        WatchService.singleton.updateWatchComplicationIfPossible()
     }
     
     fileprivate func paintScreenLockSwitch() {

--- a/nightguard/MainViewController.swift
+++ b/nightguard/MainViewController.swift
@@ -304,6 +304,7 @@ class MainViewController: UIViewController {
                     self.feedbackPanelView.isHidden = true
                     self.paintCurrentBgData(currentNightscoutData: newNightscoutData)
                     
+                    WatchService.singleton.sendToWatchCurrentNightwatchData()
                     WatchService.singleton.updateWatchComplicationIfPossible()
                 }
             }

--- a/nightguard/MainViewController.swift
+++ b/nightguard/MainViewController.swift
@@ -304,7 +304,7 @@ class MainViewController: UIViewController {
                     self.feedbackPanelView.isHidden = true
                     self.paintCurrentBgData(currentNightscoutData: newNightscoutData)
                     
-                    WatchService.singleton.updateWatchComplicationIfPossible()
+//                    WatchService.singleton.updateWatchComplicationIfPossible()
                 }
             }
         })

--- a/nightguard/MainViewController.swift
+++ b/nightguard/MainViewController.swift
@@ -304,7 +304,7 @@ class MainViewController: UIViewController {
                     self.feedbackPanelView.isHidden = true
                     self.paintCurrentBgData(currentNightscoutData: newNightscoutData)
                     
-//                    WatchService.singleton.updateWatchComplicationIfPossible()
+                    WatchService.singleton.updateWatchComplicationIfPossible()
                 }
             }
         })

--- a/nightguard/MainViewController.swift
+++ b/nightguard/MainViewController.swift
@@ -305,7 +305,6 @@ class MainViewController: UIViewController {
                     self.paintCurrentBgData(currentNightscoutData: newNightscoutData)
                     
                     WatchService.singleton.sendToWatchCurrentNightwatchData()
-                    WatchService.singleton.updateWatchComplicationIfPossible()
                 }
             }
         })

--- a/nightguard/MainViewController.swift
+++ b/nightguard/MainViewController.swift
@@ -180,8 +180,6 @@ class MainViewController: UIViewController {
         // => in that case the user has to know that the values are old!
         loadAndPaintCurrentBgData()
         loadAndPaintChartData(forceRepaint: false)
-        
-        WatchService.singleton.updateWatchComplicationIfPossible()
     }
     
     fileprivate func paintScreenLockSwitch() {
@@ -305,6 +303,8 @@ class MainViewController: UIViewController {
                 } else if let newNightscoutData = newNightscoutData {
                     self.feedbackPanelView.isHidden = true
                     self.paintCurrentBgData(currentNightscoutData: newNightscoutData)
+                    
+                    WatchService.singleton.updateWatchComplicationIfPossible()
                 }
             }
         })

--- a/nightguard/NightscoutData.swift
+++ b/nightguard/NightscoutData.swift
@@ -138,8 +138,6 @@ class NightscoutData : NSObject, NSCoding, Codable {
         self.time = NSNumber(floatLiteral: try container.decode(Double.self, forKey: .time))
         self.battery = try container.decode(String.self, forKey: .battery)
         self.iob = try container.decode(String.self, forKey: .iob)
-        self.rawbg = try container.decode(String.self, forKey: .rawbg)
-        self.noise = try container.decode(String.self, forKey: .noise)
     }
     
     /// Encodes this value into the given encoder.
@@ -160,8 +158,6 @@ class NightscoutData : NSObject, NSCoding, Codable {
         try container.encode(self.time.doubleValue, forKey: .time)
         try container.encode(self.battery, forKey: .battery)
         try container.encode(self.iob, forKey: .iob)
-        try container.encode(self.rawbg, forKey: .rawbg)
-        try container.encode(self.noise, forKey: .noise)
     }
     
     func isOlderThan5Minutes() -> Bool {

--- a/nightguard/NightscoutData.swift
+++ b/nightguard/NightscoutData.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // Contains all available information of a current Blood Glucose value.
 // This data can be stored in the user defaults.
-class NightscoutData : NSObject, NSCoding {
+class NightscoutData : NSObject, NSCoding, Codable {
     
     var sgv : String = "---"
     var bgdeltaString : String = "---"
@@ -46,11 +46,24 @@ class NightscoutData : NSObject, NSCoding {
     var battery : String = "---"
     var iob : String = ""
     
-    // NSCoder methods to make this class serializable
-    
     override init () {
         super.init()
     }
+    
+    enum CodingKeys: String, CodingKey {
+        case sgv
+        case bgdeltaString
+        case bgdeltaArrow
+        case bgdelta
+        case time
+        case battery
+        case iob
+        case rawbg
+        case noise
+    }
+
+    
+    // MARK:- NSCoding interface implementation
     
     /* 
         Code to deserialize BgData content. The error handling is need in case that old serialized
@@ -95,8 +108,8 @@ class NightscoutData : NSObject, NSCoding {
     }
     
     /*
-        Code to serialize the BgData to store them in UserDefaults.
-    */
+     Code to serialize the BgData to store them in UserDefaults.
+     */
     func encode(with aCoder: NSCoder) {
         aCoder.encode(self.sgv, forKey: "sgv")
         aCoder.encode(self.bgdeltaString, forKey: "bgdeltaString")
@@ -105,6 +118,50 @@ class NightscoutData : NSObject, NSCoding {
         aCoder.encode(self.time, forKey: "time")
         aCoder.encode(self.battery, forKey: "battery")
         aCoder.encode(self.iob, forKey: "iob")
+    }
+    
+    
+    // MARK:- Codable interface implementation
+    
+    /// Creates a new instance by decoding from the given decoder.
+    ///
+    /// This initializer throws an error if reading from the decoder fails, or
+    /// if the data read is corrupted or otherwise invalid.
+    ///
+    /// - Parameter decoder: The decoder to read data from.
+    required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.sgv = try container.decode(String.self, forKey: .sgv)
+        self.bgdeltaString = try container.decode(String.self, forKey: .bgdeltaString)
+        self.bgdeltaArrow = try container.decode(String.self, forKey: .bgdeltaArrow)
+        self.bgdelta = try container.decode(Float.self, forKey: .bgdelta)
+        self.time = NSNumber(floatLiteral: try container.decode(Double.self, forKey: .time))
+        self.battery = try container.decode(String.self, forKey: .battery)
+        self.iob = try container.decode(String.self, forKey: .iob)
+        self.rawbg = try container.decode(String.self, forKey: .rawbg)
+        self.noise = try container.decode(String.self, forKey: .noise)
+    }
+    
+    /// Encodes this value into the given encoder.
+    ///
+    /// If the value fails to encode anything, `encoder` will encode an empty
+    /// keyed container in its place.
+    ///
+    /// This function throws an error if any values are invalid for the given
+    /// encoder's format.
+    ///
+    /// - Parameter encoder: The encoder to write data to.
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.sgv, forKey: .sgv)
+        try container.encode(self.bgdeltaString, forKey: .bgdeltaString)
+        try container.encode(self.bgdeltaArrow, forKey: .bgdeltaArrow)
+        try container.encode(self.bgdelta, forKey: .bgdelta)
+        try container.encode(self.time.doubleValue, forKey: .time)
+        try container.encode(self.battery, forKey: .battery)
+        try container.encode(self.iob, forKey: .iob)
+        try container.encode(self.rawbg, forKey: .rawbg)
+        try container.encode(self.noise, forKey: .noise)
     }
     
     func isOlderThan5Minutes() -> Bool {
@@ -118,3 +175,4 @@ class NightscoutData : NSObject, NSCoding {
         return timeInterval > minutes * 60
     }
 }
+

--- a/nightguard/WatchMessageService.swift
+++ b/nightguard/WatchMessageService.swift
@@ -15,9 +15,21 @@ class WatchMessageService : NSObject, WCSessionDelegate {
     
     static let singleton = WatchMessageService()
     
+    var currentNightscoutDataAsMessage: [String : Any] {
+        
+        let nightscoutData = NightscoutCacheService.singleton.getCurrentNightscoutData()
+        let encodedNightscoutData = try? JSONEncoder().encode(nightscoutData)
+        return ["nightscoutData": encodedNightscoutData ?? Data()]
+    }
+    
     // This method gets called when the watch requests the baseUri from the Nightscout Backend
     func session(_ session: WCSession, didReceiveMessage message: [String : Any], replyHandler: @escaping ([String : Any]) -> Void) {
-        replyHandler(["baseUri": UserDefaultsRepository.readBaseUri()])
+        
+        if message["requestBaseUri"] != nil {
+            replyHandler(["baseUri": UserDefaultsRepository.readBaseUri()])
+        } else if message["requestNightscoutData"] != nil {            
+            replyHandler(currentNightscoutDataAsMessage)
+        }
     }
     
     @available(iOS 9.3, *)

--- a/nightguard/WatchMessageService.swift
+++ b/nightguard/WatchMessageService.swift
@@ -27,8 +27,6 @@ class WatchMessageService : NSObject, WCSessionDelegate {
         
         if message["requestBaseUri"] != nil {
             replyHandler(["baseUri": UserDefaultsRepository.readBaseUri()])
-        } else if message["requestNightscoutData"] != nil {            
-            replyHandler(currentNightscoutDataAsMessage)
         }
     }
     

--- a/nightguard/WatchService.swift
+++ b/nightguard/WatchService.swift
@@ -44,7 +44,7 @@ class WatchService {
     func updateWatchComplicationIfPossible() {
         
         let calendar = Calendar.current
-        if let lastWatchComplicationUpdateTime = self.lastWatchComplicationUpdateTime, calendar.date(byAdding: .minute, value: self.watchComplicationUpdateRate, to: lastWatchComplicationUpdateTime)! > Date() {
+        if let lastWatchComplicationUpdateTime = self.lastWatchComplicationUpdateTime, calendar.date(byAdding: .minute, value: self.watchComplicationUpdateRate, to: lastWatchComplicationUpdateTime)! >= Date() {
             
             // last watch complication update was more recent than update rate, will skip updating it now!
             return

--- a/nightguard/WatchService.swift
+++ b/nightguard/WatchService.swift
@@ -105,25 +105,4 @@ class WatchService {
             }
         }
     }
-        
-//        // update complication also (but respect the update rate - 30 minutes)
-//        if WCSession.default.isComplicationEnabled {
-//
-//            if let lastWatchComplicationUpdateTime = self.lastWatchComplicationUpdateTime, Calendar.current.date(byAdding: .minute, value: self.watchComplicationUpdateRate, to: lastWatchComplicationUpdateTime)! >= Date() {
-//
-//                // do nothing, last watch complication update was more recent than update rate, will skip updating it now!
-//            } else {
-//
-//                // send in user info along the nightscout data a flag to signal that we want to update complications also
-//                var userInfo = WatchMessageService.singleton.currentNightscoutDataAsMessage
-//                userInfo["updateComplication"] = true
-//
-//                // update!
-//                WCSession.default.transferCurrentComplicationUserInfo(userInfo)
-//
-//                // and keep the update time
-//                self.lastWatchComplicationUpdateTime = Date()
-//            }
-//        }
-    }
 }

--- a/nightguard/WatchService.swift
+++ b/nightguard/WatchService.swift
@@ -14,10 +14,10 @@ class WatchService {
     static let singleton = WatchService()
     
     // watch app update frequency (when have new nightscout data)
-    var watchUpdateRate: Int = 5 // minutes
+    private let watchUpdateRate: Int = BackgroundRefreshSettings.watchUpdateRate
     
     // watch app complication update (when have new nightscout data)
-    var watchComplicationUpdateRate: Int = 30 // minutes (50 complication update per day guaranteed by Apple...)
+    private let watchComplicationUpdateRate: Int = BackgroundRefreshSettings.watchComplicationUpdateRate
     
     private var lastSentNightscoutDataTime: NSNumber?
     private var lastWatchUpdateTime: Date?
@@ -63,25 +63,48 @@ class WatchService {
             }
         }
         
-        if lastSentNightscoutDataTime != nightscoutData.time {
-            // Assuring we are sending ONLY once a nightscout data...
-            // ... and respecting the update rate!
-            if let lastWatchUpdateTime = self.lastWatchUpdateTime, Calendar.current.date(byAdding: .minute, value: self.watchUpdateRate, to: lastWatchUpdateTime)! >= Date() {
-                
-                // do nothing, last watch update was more recent than update rate, will skip updating it now!
-            } else {
-                
-                // do update!
-                try? WCSession.default.updateApplicationContext(
-                    WatchMessageService.singleton.currentNightscoutDataAsMessage
-                )
+        // update watch (if configured so)
+        if BackgroundRefreshSettings.enableWatchUpdate {
+            
+            if lastSentNightscoutDataTime != nightscoutData.time {
+                // Assuring we are sending ONLY once a nightscout data...
+                // ... and respecting the update rate!
+                if let lastWatchUpdateTime = self.lastWatchUpdateTime, Calendar.current.date(byAdding: .minute, value: self.watchUpdateRate, to: lastWatchUpdateTime)! >= Date() {
+                    
+                    // do nothing, last watch update was more recent than update rate, will skip updating it now!
+                } else {
+                    
+                    // do update!
+                    try? WCSession.default.updateApplicationContext(
+                        WatchMessageService.singleton.currentNightscoutDataAsMessage
+                    )
 
-                self.lastSentNightscoutDataTime = nightscoutData.time
-                self.lastWatchUpdateTime = Date()
+                    self.lastSentNightscoutDataTime = nightscoutData.time
+                    self.lastWatchUpdateTime = Date()
+                }
             }
         }
         
-        // NOTE: complication update is not needed anymore, as we provide data from 5 in 5 minutes on application context (if we send complication updates also, both updates will arrive at the same time... so useless to do it!)
+        // update watch complication (if configured so)
+        if BackgroundRefreshSettings.enableWatchComplicationUpdate && WCSession.default.isComplicationEnabled {
+
+            if let lastWatchComplicationUpdateTime = self.lastWatchComplicationUpdateTime, Calendar.current.date(byAdding: .minute, value: self.watchComplicationUpdateRate, to: lastWatchComplicationUpdateTime)! >= Date() {
+
+                // do nothing, last watch complication update was more recent than update rate, will skip updating it now!
+            } else {
+
+                // send in user info along the nightscout data a flag to signal that we want to update complications also
+                var userInfo = WatchMessageService.singleton.currentNightscoutDataAsMessage
+                userInfo["updateComplication"] = true
+
+                // update!
+                WCSession.default.transferCurrentComplicationUserInfo(userInfo)
+
+                // and keep the update time
+                self.lastWatchComplicationUpdateTime = Date()
+            }
+        }
+    }
         
 //        // update complication also (but respect the update rate - 30 minutes)
 //        if WCSession.default.isComplicationEnabled {

--- a/nightguard/WatchService.swift
+++ b/nightguard/WatchService.swift
@@ -13,6 +13,9 @@ class WatchService {
     
     static let singleton = WatchService()
     
+    private var lastWatchComplicationUpdateTime: Date?
+    private let watchComplicationUpdateRate: Int = 30 // minutes (50 update per day guaranteed by Apple...)
+    
     func sendToWatch(_ units : Units) {
         let applicationDict = ["units" : units.rawValue]
         WCSession.default.transferUserInfo(applicationDict)
@@ -36,5 +39,31 @@ class WatchService {
              "alertIfAboveValue" : alertIfAboveValue,
              "units" : units.rawValue]
         WCSession.default.transferUserInfo(applicationDict as [String : AnyObject])
+    }
+    
+    func updateWatchComplicationIfPossible() {
+        
+        let calendar = Calendar.current
+        if let lastWatchComplicationUpdateTime = self.lastWatchComplicationUpdateTime, calendar.date(byAdding: .minute, value: self.watchComplicationUpdateRate, to: lastWatchComplicationUpdateTime)! > Date() {
+            
+            // last watch complication update was more recent than update rate, will skip updating it now!
+            return
+        }
+        
+        var shouldUpdate = true
+        if #available(iOS 9.3, *) {
+            shouldUpdate = WCSession.default.activationState == .activated && WCSession.default.isComplicationEnabled
+        }
+        
+        if shouldUpdate {
+                
+            // update!
+            WCSession.default.transferCurrentComplicationUserInfo(
+                WatchMessageService.singleton.currentNightscoutDataAsMessage
+            )
+            
+            // and keep the update time
+            self.lastWatchComplicationUpdateTime = Date()
+        }
     }
 }

--- a/nightguard/WatchService.swift
+++ b/nightguard/WatchService.swift
@@ -52,7 +52,7 @@ class WatchService {
         
         // send ONLY if the phone app has new nightscout data
         let nightscoutData = NightscoutCacheService.singleton.getCurrentNightscoutData()
-        guard !nightscoutData.isOlderThan5Minutes() else {
+        guard !nightscoutData.isOlderThanXMinutes(15) else {
             return
         }
         

--- a/nightguard/WatchService.swift
+++ b/nightguard/WatchService.swift
@@ -13,6 +13,7 @@ class WatchService {
     
     static let singleton = WatchService()
     
+    private var lastSentNightscoutDataTime: NSNumber?
     private var lastWatchComplicationUpdateTime: Date?
     private let watchComplicationUpdateRate: Int = 30 // minutes (50 update per day guaranteed by Apple...)
     
@@ -39,6 +40,19 @@ class WatchService {
              "alertIfAboveValue" : alertIfAboveValue,
              "units" : units.rawValue]
         WCSession.default.transferUserInfo(applicationDict as [String : AnyObject])
+    }
+    
+    func sendToWatchCurrentNightwatchData() {
+        
+//        let nightscoutData = NightscoutCacheService.singleton.getCurrentNightscoutData()
+//        if lastSentNightscoutDataTime != nightscoutData.time {
+//
+//            try? WCSession.default.updateApplicationContext(
+//                WatchMessageService.singleton.currentNightscoutDataAsMessage
+//            )
+//
+//            self.lastSentNightscoutDataTime = nightscoutData.time
+//        }
     }
     
     func updateWatchComplicationIfPossible() {


### PR DESCRIPTION
Finally, after a marathon of two weeks (mostly nights), more trial & error approaches (some great stackoverflow posts provided great help - the links are between comments in the code) background updates are working! Still unreliable, if compared with Pebble instant watchface values, but they work in the "Apple" way. The fact is that background time is limited for apps, also their capability to update the watch complication. If quota is exceeded, the updates come more rarely, offending apps could also be killed (if spending too much time in background tasks). Ok, so do not expect constancy in the way the complication are updated. 

Ok, so what I got for the moment:
There are two ways of updating the nightscout data when the watch is in background:
1. URL sessions, scheduled from background task (also scheduled regularly, configurable interval in BackgroundRefreshSettings class - feel free to experiment with different intervals)
2. Background fetches from phone app that updates the watch by transferring the new nightscout data as application context
Each aspect of those two methods can be configured in the BackgroundRefreshSettings class (enabling, intervals, etc). 
There is also a log that is displayed in the watch Info screen for analyzing / debugging background tasks and what data was received (and when) through URL sessions, respectively from the phone app.
![backgroundtaskslog](https://user-images.githubusercontent.com/16608127/37821363-0971a306-2e8c-11e8-9165-12d7e8e3ada0.jpg)


Along with the background updates, there are implemented two nice things also:
* request for nightscout data on watch app is triggered only if the current nightscout data is old (older than 5 minutes); a nice effect is that sometimes, when the watch app received the new nightscout data from the phone app, the new reading is already there when opening the watch app (or raising the 
wrist)
* modified the modular complications to show relative time instead of absolute (the relative time is automatically managed by watchOS); there is a flag to control the preference of showing relative or absolute time (hardcoded for the moment, can be a checkbox in settings if it makes sense...)
![modularsmallcomplication](https://user-images.githubusercontent.com/16608127/37821251-cd7e8f1c-2e8b-11e8-880d-59b76d7a3275.jpg)
![modulalargercomplication](https://user-images.githubusercontent.com/16608127/37821265-d3d19814-2e8b-11e8-8c35-97eacd8b13e4.jpg)

So... feel free to experiment and continue improving it, even refactor some things. For example, the BackgroundUrlSessionWrapper class is not used anymore (but still exists!), all URL session related work is implemented in ExtensionDelegate. 

Also, note that there is a data redundancy when receiving the same data from phone app and from URL session (usually in the same time, because when the watch app receives some background time, it performs more tasks at once). More intelligence can be also added to reduce consuming background time when is not really needed, but there is no guaranty watchOS will be more generous with our app or the complication refreshes will be on time. Even the phone app background fetches cannot be fixed in time for getting nightscout data early (ideally, when published). We should rely on silent pushes for that... and we need a backend, webhooks (maybe IFTTT can work), etc.
