### PR TITLE
Do not show on chart invalid bg values (under 10)

### DIFF
--- a/nightguard WatchKit Extension/ChartPainter.swift
+++ b/nightguard WatchKit Extension/ChartPainter.swift
@@ -134,8 +134,16 @@ class ChartPainter {
         }
         for currentPoint in 1...maxPoints-1 {
             
-            let beginOfLineYValue = calcYValue(Float(min(CGFloat(bgValues[currentPoint-1].value), value2: maxBgValue)))
-            let endOfLineYValue = calcYValue(Float(min(CGFloat(bgValues[currentPoint].value), value2: maxBgValue)))
+            let beginBGValue = bgValues[currentPoint-1]
+            let endBGValue = bgValues[currentPoint]
+            
+            // skip drawing lines if at least one BG value is invalid
+            guard beginBGValue.isValid && endBGValue.isValid else {
+                continue
+            }
+            
+            let beginOfLineYValue = calcYValue(Float(min(CGFloat(beginBGValue.value), value2: maxBgValue)))
+            let endOfLineYValue = calcYValue(Float(min(CGFloat(endBGValue.value), value2: maxBgValue)))
     
             let maxYValue = calcYValue(Float(maxBgValue))
             
@@ -413,6 +421,11 @@ class ChartPainter {
         
         for bgValues in days {
             for bgValue in bgValues {
+                
+                guard bgValue.isValid else {
+                    continue
+                }
+                
                 if bgValue.value < newMinYValue {
                     newMinYValue = bgValue.value
                 }

--- a/nightguard/BloodSugar.swift
+++ b/nightguard/BloodSugar.swift
@@ -19,6 +19,11 @@ class BloodSugar : NSCoder {
         self.timestamp = timestamp
     }
     
+    // when the noise is very strong, values are not computable... and we should exclude them from any logic & presentation
+    var isValid: Bool {
+        return self.value > 10
+    }
+    
     @objc required convenience init(coder decoder: NSCoder) {
 
         // only initialize if base values could be decoded


### PR DESCRIPTION
When the sensor is old, it starts having more noise and the values are displayed as ???, NC on nightscout, xdrip or Dexcom receiver (only raw value are sometimes available). It was annoying that nightguard displayed that value (usually a 10 mg/dl) and the watch app zoomed out, losing considerably space. 
My solution is to not show those invalid BG values.
![yesterdays-gaps-1](https://user-images.githubusercontent.com/16608127/38099936-90752fe2-3384-11e8-8fc1-9b1f6c61291e.jpg)
![yesterdays-gaps-2](https://user-images.githubusercontent.com/16608127/38099937-909300c6-3384-11e8-8d59-2e84f284bad2.jpg)

