### PR TITLE
docs: fix 2 broken hyperlinks in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 This is an iPhone and Apple Watch application to display blood glucose values stored at your nightscout server.
 
 # Description
-This app displays the last 30 Values from your [nightscout] (http://www.nightscout.info) [server] (https://github.com/nightscout/cgm-remote-monitor):
+This app displays the last 30 Values from your [nightscout](http://www.nightscout.info) [server](https://github.com/nightscout/cgm-remote-monitor):
 
 ![Nightguard Main-Screen](https://github.com/nightscout/nightguard/blob/master/images/screen1.jpg)
 ![Nightguard Alarm-Screen](https://github.com/nightscout/nightguard/blob/master/images/screen2.jpg)


### PR DESCRIPTION
Remove stray whitespace separating label and URL in Markdown link syntax usages.