### PR TITLE
Fix bugs in BG array and alarm rule code when units are expressed in mmol

### DIFF
--- a/nightguard/AlarmRule.swift
+++ b/nightguard/AlarmRule.swift
@@ -68,9 +68,8 @@ class AlarmRule {
             return "Missed Readings"
         }
         
-        let svgInMgdl = UnitsConverter.toMgdl(currentReading.value)
-        let isTooHigh = AlarmRule.isTooHigh(svgInMgdl)
-        let isTooLow = AlarmRule.isTooLow(svgInMgdl)
+        let isTooHigh = AlarmRule.isTooHigh(currentReading.value)
+        let isTooLow = AlarmRule.isTooLow(currentReading.value)
         
         if isSmartSnoozeEnabled && (isTooHigh || isTooLow) {
             
@@ -91,9 +90,9 @@ class AlarmRule {
             }
             
             // let's try also with prediction: we'll snooze the alarm if the prediction says that we'll leave the too high or too low zone in less than 30 minutes
-            if isTooHigh && (PredictionService.singleton.minutesTo(low: UnitsConverter.toDisplayUnits(alertIfAboveValue)) ?? Int.max) < 30 {
+            if isTooHigh && (PredictionService.singleton.minutesTo(low: alertIfAboveValue) ?? Int.max) < 30 {
                 return nil
-            } else if isTooLow && (PredictionService.singleton.minutesTo(high: UnitsConverter.toDisplayUnits(alertIfBelowValue)) ?? Int.max) < 30 {
+            } else if isTooLow && (PredictionService.singleton.minutesTo(high: alertIfBelowValue) ?? Int.max) < 30 {
                 return nil
             }
         }
@@ -113,7 +112,7 @@ class AlarmRule {
         }
         
         if isLowPredictionEnabled {
-            if let minutesToLow = PredictionService.singleton.minutesTo(low: UnitsConverter.toDisplayUnits(alertIfBelowValue)), minutesToLow <= minutesToPredictLow {
+            if let minutesToLow = PredictionService.singleton.minutesTo(low: alertIfBelowValue), minutesToLow <= minutesToPredictLow {
                 #if os(iOS)
                 return "Low Predicted in \(minutesToLow)min"
                 #else

--- a/nightguard/BloodSugarArrayExtension.swift
+++ b/nightguard/BloodSugarArrayExtension.swift
@@ -17,6 +17,7 @@ enum BloodSugarTrend {
 
 extension Array where Element: BloodSugar {
 
+    /// return today's readings from repositories (readings are always in mg/dL)
     static func latestFromRepositories() -> [BloodSugar] {
         
         // get today's data
@@ -68,9 +69,9 @@ extension Array where Element: BloodSugar {
             return .unknown
         }
         
-        let deltasInMgdl = readings.deltas.map { UnitsConverter.toMgdl($0) }
-        if abs(deltasInMgdl[1]) > 4 || abs(deltasInMgdl[0] + deltasInMgdl[1]) > 10 {
-            return deltasInMgdl[0] > 0 ? .ascending : .descending
+        let deltas = readings.deltas // deltas (differences between 2 values expressed in mg/dL)
+        if abs(deltas[1]) > 4 || abs(deltas[0] + deltas[1]) > 10 {
+            return deltas[1] > 0 ? .ascending : .descending
         } else {
             return .unknown
         }
@@ -100,8 +101,10 @@ extension Array where Element: BloodSugar {
     mutating func assureCurrentReadingExists(_ nightscoutData: NightscoutData) {
         
         if (self.last?.timestamp ?? 0) < nightscoutData.time.doubleValue {
+            
+            // NOTE: convert current reading units to mg/dL (readings are always in mg/dL)
             self.append(
-                Element (value: Float(nightscoutData.sgv)!, timestamp: nightscoutData.time.doubleValue)
+                Element (value: UnitsConverter.toMgdl(Float(nightscoutData.sgv)!), timestamp: nightscoutData.time.doubleValue)
             )
         }
     }

--- a/nightguard/MainViewController.swift
+++ b/nightguard/MainViewController.swift
@@ -289,7 +289,7 @@ class MainViewController: UIViewController {
         if subtitle == nil {
             
             // no alarm, but maybe we'll show a low prediction warning...
-            if let minutesToLow = PredictionService.singleton.minutesTo(low: UnitsConverter.toDisplayUnits(AlarmRule.alertIfBelowValue)), minutesToLow > 0 {
+            if let minutesToLow = PredictionService.singleton.minutesTo(low: AlarmRule.alertIfBelowValue), minutesToLow > 0 {
                 subtitle = "Low Predicted in \(minutesToLow)min"
                 subtitleColor = .yellow
             }


### PR DESCRIPTION
This is a fix for #59 