### PR TITLE
Fix landscape status bar when rotating the phone

### DIFF
--- a/nightguard/Info.plist
+++ b/nightguard/Info.plist
@@ -39,8 +39,6 @@
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>
 	<array>
 		<string>armv7</string>


### PR DESCRIPTION
When rotating the phone, the status bar is displayed as landscape/portrait, as the phone orientation is (the app remains in portrait mode correctly). 

This fix corrects the status bar behavior.
<img width="901" alt="screen shot 2019-03-08 at 11 24 26 am" src="https://user-images.githubusercontent.com/16608127/54020069-9529fc00-4195-11e9-8c5a-a7f95385e30d.png">
