### PR TITLE
Daily stats feature

### DIFF
--- a/nightguard WatchKit Extension/ChartPainter.swift
+++ b/nightguard WatchKit Extension/ChartPainter.swift
@@ -301,7 +301,8 @@ class ChartPainter {
     }
     
     fileprivate func durationIsMoreThan6Hours(_ minTimestamp : Double, maxTimestamp : Double) -> Bool {
-        return maxTimestamp - minTimestamp > 6 * 60 * 60 * 1000
+        let sixHours = Double(6 * 60 * 60 * 1000)
+        return (maxTimestamp - minTimestamp) > sixHours
     }
     
     fileprivate func paintEverySecondHour(_ context : CGContext, attrs : [NSAttributedStringKey : Any]) {

--- a/nightguard WatchKit Extension/UserDefaultsRepository.swift
+++ b/nightguard WatchKit Extension/UserDefaultsRepository.swift
@@ -100,6 +100,9 @@ class UserDefaultsRepository {
     static let volumeKeysOnAlertSnoozeOption = UserDefaultsValue<QuickSnoozeOption>(key: "volumeKeysOnAlertSnoozeOption", default: .doNothing)
     #endif
     
+    // show/hide stats
+    static let showStats = UserDefaultsValue<Bool>(key: "showStats", default: true)
+    
     /* Parses the URI entered in the UI and extracts the token if one is present. */
     fileprivate static func parseBaseUri() {
         url = nil

--- a/nightguard.xcodeproj/project.pbxproj
+++ b/nightguard.xcodeproj/project.pbxproj
@@ -130,6 +130,10 @@
 		D133079B21C85FAE00DC6879 /* Matrix.swift in Sources */ = {isa = PBXBuildFile; fileRef = D133079121C85FAE00DC6879 /* Matrix.swift */; };
 		D133079E21C8D4CF00DC6879 /* PredictionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D133079D21C8D4CF00DC6879 /* PredictionService.swift */; };
 		D133079F21C8D4CF00DC6879 /* PredictionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D133079D21C8D4CF00DC6879 /* PredictionService.swift */; };
+		D1358AE42234F80A00D0FA87 /* SMDiagramView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1358AE32234F80A00D0FA87 /* SMDiagramView.swift */; };
+		D1358AE62234FB2600D0FA87 /* BasicStatsPanelView.xib in Resources */ = {isa = PBXBuildFile; fileRef = D1358AE52234FB2600D0FA87 /* BasicStatsPanelView.xib */; };
+		D1358AE82234FB5000D0FA87 /* BasicStatsPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1358AE72234FB5000D0FA87 /* BasicStatsPanelView.swift */; };
+		D1358AEC2237C44600D0FA87 /* XibLoadedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1358AEB2237C44600D0FA87 /* XibLoadedView.swift */; };
 		D13A4C1C2221E43A00C71F08 /* GenericWatchMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13A4C1B2221E43A00C71F08 /* GenericWatchMessage.swift */; };
 		D13A4C1D2221E43A00C71F08 /* GenericWatchMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13A4C1B2221E43A00C71F08 /* GenericWatchMessage.swift */; };
 		D13A4C1E2221E43A00C71F08 /* GenericWatchMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D13A4C1B2221E43A00C71F08 /* GenericWatchMessage.swift */; };
@@ -201,6 +205,11 @@
 		D1F2F57C21EF133600CEB874 /* Matrix+Append.swift in Sources */ = {isa = PBXBuildFile; fileRef = D133078E21C85FAC00DC6879 /* Matrix+Append.swift */; };
 		D1F2F57D21EF133A00CEB874 /* Matrix+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = D133078F21C85FAD00DC6879 /* Matrix+Description.swift */; };
 		D1F2F57E21EF134400CEB874 /* RegressionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D133078D21C85FAC00DC6879 /* RegressionHelper.swift */; };
+		D1F94ECC223FFDF200BB0A4D /* BasicStatsControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F94ECB223FFDF100BB0A4D /* BasicStatsControl.swift */; };
+		D1F94ECE223FFE2A00BB0A4D /* GlucoseDistributionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F94ECD223FFE2A00BB0A4D /* GlucoseDistributionView.swift */; };
+		D1F94ED0223FFEFF00BB0A4D /* A1cView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F94ECF223FFEFF00BB0A4D /* A1cView.swift */; };
+		D1F94ED2223FFF3900BB0A4D /* ReadingsStatsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F94ED1223FFF3900BB0A4D /* ReadingsStatsView.swift */; };
+		D1F94ED4223FFF6C00BB0A4D /* StatsPeriodSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F94ED3223FFF6C00BB0A4D /* StatsPeriodSelectorView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -349,6 +358,10 @@
 		D133079021C85FAD00DC6879 /* Regression.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Regression.swift; sourceTree = "<group>"; };
 		D133079121C85FAE00DC6879 /* Matrix.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Matrix.swift; sourceTree = "<group>"; };
 		D133079D21C8D4CF00DC6879 /* PredictionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredictionService.swift; sourceTree = "<group>"; };
+		D1358AE32234F80A00D0FA87 /* SMDiagramView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SMDiagramView.swift; sourceTree = "<group>"; };
+		D1358AE52234FB2600D0FA87 /* BasicStatsPanelView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BasicStatsPanelView.xib; sourceTree = "<group>"; };
+		D1358AE72234FB5000D0FA87 /* BasicStatsPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicStatsPanelView.swift; sourceTree = "<group>"; };
+		D1358AEB2237C44600D0FA87 /* XibLoadedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XibLoadedView.swift; sourceTree = "<group>"; };
 		D13A4C1B2221E43A00C71F08 /* GenericWatchMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericWatchMessage.swift; sourceTree = "<group>"; };
 		D13A4C1F2221E49200C71F08 /* NightSafeMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NightSafeMessage.swift; sourceTree = "<group>"; };
 		D15055AB2200CD6500F31C1F /* UserDefaultsValueGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsValueGroups.swift; sourceTree = "<group>"; };
@@ -392,6 +405,11 @@
 		D1EBB6A82223FF0200CE27FF /* MissedReadingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MissedReadingsViewController.swift; sourceTree = "<group>"; };
 		D1ECDA1E2201075B002BE6F9 /* ObservationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservationToken.swift; sourceTree = "<group>"; };
 		D1ECDA252202C8F0002BE6F9 /* UIColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
+		D1F94ECB223FFDF100BB0A4D /* BasicStatsControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicStatsControl.swift; sourceTree = "<group>"; };
+		D1F94ECD223FFE2A00BB0A4D /* GlucoseDistributionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlucoseDistributionView.swift; sourceTree = "<group>"; };
+		D1F94ECF223FFEFF00BB0A4D /* A1cView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = A1cView.swift; sourceTree = "<group>"; };
+		D1F94ED1223FFF3900BB0A4D /* ReadingsStatsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingsStatsView.swift; sourceTree = "<group>"; };
+		D1F94ED3223FFF6C00BB0A4D /* StatsPeriodSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsPeriodSelectorView.swift; sourceTree = "<group>"; };
 		DFAB5E556FA57C770FDF2924 /* Pods_nightguardTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_nightguardTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FDA8B19A6EB3652EEDD03592 /* Pods_nightguardUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_nightguardUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FE4022D9F5273F6FF43EA39D /* Pods_nightguard_WatchKit_Extension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_nightguard_WatchKit_Extension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -733,9 +751,11 @@
 		D1BA903620D303E700A0EBD1 /* views */ = {
 			isa = PBXGroup;
 			children = (
+				D1F94ECA223FFD5400BB0A4D /* stats */,
 				D1BA903420D3033500A0EBD1 /* GroupedLabelsView.swift */,
 				D1BA903720D3046600A0EBD1 /* PaddingLabel.swift */,
 				D1BA903920D304BE00A0EBD1 /* UIView+Extensions.swift */,
+				D1358AEB2237C44600D0FA87 /* XibLoadedView.swift */,
 			);
 			name = views;
 			sourceTree = "<group>";
@@ -748,6 +768,21 @@
 				D1D96CB921FB0E910035A60E /* WatchMessageService.swift */,
 			);
 			name = watch;
+			sourceTree = "<group>";
+		};
+		D1F94ECA223FFD5400BB0A4D /* stats */ = {
+			isa = PBXGroup;
+			children = (
+				D1358AE32234F80A00D0FA87 /* SMDiagramView.swift */,
+				D1F94ECB223FFDF100BB0A4D /* BasicStatsControl.swift */,
+				D1F94ECF223FFEFF00BB0A4D /* A1cView.swift */,
+				D1F94ECD223FFE2A00BB0A4D /* GlucoseDistributionView.swift */,
+				D1F94ED1223FFF3900BB0A4D /* ReadingsStatsView.swift */,
+				D1F94ED3223FFF6C00BB0A4D /* StatsPeriodSelectorView.swift */,
+				D1358AE52234FB2600D0FA87 /* BasicStatsPanelView.xib */,
+				D1358AE72234FB5000D0FA87 /* BasicStatsPanelView.swift */,
+			);
+			name = stats;
 			sourceTree = "<group>";
 		};
 		D1FAA4AB20D7AE6B0062B333 /* controllers */ = {
@@ -945,6 +980,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D1358AE62234FB2600D0FA87 /* BasicStatsPanelView.xib in Resources */,
 				D1DA7C7521C0E1ED00B39675 /* Stats.storyboard in Resources */,
 				43647BD81BFF6435004389F9 /* LaunchScreen.storyboard in Resources */,
 				43F1E1061D07698000C329A2 /* Media.xcassets in Resources */,
@@ -1145,6 +1181,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D1358AE82234FB5000D0FA87 /* BasicStatsPanelView.swift in Sources */,
 				D1D96CC321FB0FA80035A60E /* SnoozeMessage.swift in Sources */,
 				D1D1623C2218BF7A006F990A /* UIScreen+AnimatedBrightness.swift in Sources */,
 				D1BA903820D3046600A0EBD1 /* PaddingLabel.swift in Sources */,
@@ -1156,6 +1193,7 @@
 				D16C8EDD22106C9300192117 /* QuickSnoozeOption.swift in Sources */,
 				437EEDC11FB70FC200694EAD /* NightscoutCacheService.swift in Sources */,
 				D160D08A220C608D002B4633 /* FastRiseDropViewController.swift in Sources */,
+				D1F94ED0223FFEFF00BB0A4D /* A1cView.swift in Sources */,
 				43119B891C38404200DD6D35 /* NightscoutDataRepository.swift in Sources */,
 				D133079621C85FAE00DC6879 /* Matrix+Description.swift in Sources */,
 				D1CE8CC42204B19C0075FF8A /* CustomFormViewController.swift in Sources */,
@@ -1171,6 +1209,7 @@
 				D16C8EDF2211047300192117 /* UIViewController+Extensions.swift in Sources */,
 				D1ECDA262202C8F0002BE6F9 /* UIColorExtension.swift in Sources */,
 				D15055AC2200CD6500F31C1F /* UserDefaultsValueGroups.swift in Sources */,
+				D1F94ECE223FFE2A00BB0A4D /* GlucoseDistributionView.swift in Sources */,
 				D160D086220C534E002B4633 /* ButtonRowWithDynamicDetails.swift in Sources */,
 				D133079A21C85FAE00DC6879 /* Matrix.swift in Sources */,
 				4351E6B01D2EFA8C001E4AE4 /* StatisticsRepository.swift in Sources */,
@@ -1184,11 +1223,14 @@
 				43119B831C382BBB00DD6D35 /* UserDefaultsRepository.swift in Sources */,
 				43F1E11B1D076D9700C329A2 /* TimeService.swift in Sources */,
 				D1EBB6A92223FF0200CE27FF /* MissedReadingsViewController.swift in Sources */,
+				D1F94ECC223FFDF200BB0A4D /* BasicStatsControl.swift in Sources */,
+				D1358AEC2237C44600D0FA87 /* XibLoadedView.swift in Sources */,
 				432E62EB1D15EFC600DD7978 /* FloatExtension.swift in Sources */,
 				43FCE625208B80840080DA0A /* SnoozeAlarmViewController.swift in Sources */,
 				D133079E21C8D4CF00DC6879 /* PredictionService.swift in Sources */,
 				430FD8D41E7C8738002A23F0 /* UIViewControllerExtension.swift in Sources */,
 				43F1E1051D07698000C329A2 /* MainViewController.swift in Sources */,
+				D1F94ED2223FFF3900BB0A4D /* ReadingsStatsView.swift in Sources */,
 				D1BA903520D3033500A0EBD1 /* GroupedLabelsView.swift in Sources */,
 				D13A4C1C2221E43A00C71F08 /* GenericWatchMessage.swift in Sources */,
 				D13A4C202221E49200C71F08 /* NightSafeMessage.swift in Sources */,
@@ -1198,6 +1240,7 @@
 				D123EFEE21FB782C00CE8718 /* NightscoutDataMessage.swift in Sources */,
 				D15055B02200D31300F31C1F /* DeviceSize.swift in Sources */,
 				D133079421C85FAE00DC6879 /* Matrix+Append.swift in Sources */,
+				D1358AE42234F80A00D0FA87 /* SMDiagramView.swift in Sources */,
 				43119B941C3AAE6600DD6D35 /* UIColorChanger.swift in Sources */,
 				D1D96CC021FB0F2E0035A60E /* UserDefaultsSyncMessage.swift in Sources */,
 				D1AEFED821FE00A200821DF6 /* AnyConvertible.swift in Sources */,
@@ -1210,6 +1253,7 @@
 				D1BA903A20D304BE00A0EBD1 /* UIView+Extensions.swift in Sources */,
 				D123EFEB21FB70A700CE8718 /* KeepAwakeMessage.swift in Sources */,
 				D16C8ED72210377000192117 /* SnoozeActionsViewController.swift in Sources */,
+				D1F94ED4223FFF6C00BB0A4D /* StatsPeriodSelectorView.swift in Sources */,
 				4351E6AE1D2ADFBE001E4AE4 /* StatsPrefsViewController.swift in Sources */,
 				D1D96CB621FAF6890035A60E /* WatchMessage.swift in Sources */,
 				43119B811C382A0E00DD6D35 /* AppConstants.swift in Sources */,

--- a/nightguard.xcodeproj/project.pbxproj
+++ b/nightguard.xcodeproj/project.pbxproj
@@ -160,6 +160,9 @@
 		D1AEFED921FE011B00821DF6 /* AnyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AEFED721FE00A200821DF6 /* AnyConvertible.swift */; };
 		D1AEFEDA21FE011C00821DF6 /* AnyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AEFED721FE00A200821DF6 /* AnyConvertible.swift */; };
 		D1B777E42243E27B003FEDF0 /* TouchReportingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B777E32243E27B003FEDF0 /* TouchReportingView.swift */; };
+		D1B777E62244C11B003FEDF0 /* Comparable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B777E52244C11B003FEDF0 /* Comparable+Extensions.swift */; };
+		D1B777E72244C43D003FEDF0 /* Comparable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B777E52244C11B003FEDF0 /* Comparable+Extensions.swift */; };
+		D1B777E82244C43E003FEDF0 /* Comparable+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B777E52244C11B003FEDF0 /* Comparable+Extensions.swift */; };
 		D1BA903520D3033500A0EBD1 /* GroupedLabelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1BA903420D3033500A0EBD1 /* GroupedLabelsView.swift */; };
 		D1BA903820D3046600A0EBD1 /* PaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1BA903720D3046600A0EBD1 /* PaddingLabel.swift */; };
 		D1BA903A20D304BE00A0EBD1 /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1BA903920D304BE00A0EBD1 /* UIView+Extensions.swift */; };
@@ -380,6 +383,7 @@
 		D18C5D8922293C220099D96E /* BasicStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicStats.swift; sourceTree = "<group>"; };
 		D1AEFED721FE00A200821DF6 /* AnyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyConvertible.swift; sourceTree = "<group>"; };
 		D1B777E32243E27B003FEDF0 /* TouchReportingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchReportingView.swift; sourceTree = "<group>"; };
+		D1B777E52244C11B003FEDF0 /* Comparable+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Comparable+Extensions.swift"; sourceTree = "<group>"; };
 		D1BA903420D3033500A0EBD1 /* GroupedLabelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedLabelsView.swift; sourceTree = "<group>"; };
 		D1BA903720D3046600A0EBD1 /* PaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingLabel.swift; sourceTree = "<group>"; };
 		D1BA903920D304BE00A0EBD1 /* UIView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
@@ -689,6 +693,7 @@
 				D1D1623B2218BF7A006F990A /* UIScreen+AnimatedBrightness.swift */,
 				D16C8EDE2211047300192117 /* UIViewController+Extensions.swift */,
 				D16C8EDA221068F000192117 /* VolumeChangeDetector.swift */,
+				D1B777E52244C11B003FEDF0 /* Comparable+Extensions.swift */,
 			);
 			name = helpers;
 			sourceTree = "<group>";
@@ -1223,6 +1228,7 @@
 				D16C8ED92210687200192117 /* MPVolumeViewExtension.swift in Sources */,
 				43E89E571E659102005B0A65 /* ChartScene.swift in Sources */,
 				43288A6A1D1C68D400EE3999 /* StatsViewController.swift in Sources */,
+				D1B777E62244C11B003FEDF0 /* Comparable+Extensions.swift in Sources */,
 				43119B831C382BBB00DD6D35 /* UserDefaultsRepository.swift in Sources */,
 				43F1E11B1D076D9700C329A2 /* TimeService.swift in Sources */,
 				D1EBB6A92223FF0200CE27FF /* MissedReadingsViewController.swift in Sources */,
@@ -1291,6 +1297,7 @@
 				D1ECDA202201075B002BE6F9 /* ObservationToken.swift in Sources */,
 				432E62E71D11F61500DD7978 /* UserDefaultsRepositoryTest.swift in Sources */,
 				43794F491C30489C00DB8B58 /* NightscoutDataRepository.swift in Sources */,
+				D1B777E72244C43D003FEDF0 /* Comparable+Extensions.swift in Sources */,
 				432E62E01D10AF3800DD7978 /* Units.swift in Sources */,
 				D1F2F57B21EF133000CEB874 /* Matrix.swift in Sources */,
 				432E62D91D0CC3AC00DD7978 /* BloodSugar.swift in Sources */,
@@ -1384,6 +1391,7 @@
 				D1D96CC121FB0F2E0035A60E /* UserDefaultsSyncMessage.swift in Sources */,
 				D133078A21C85D5400DC6879 /* BloodSugarArrayExtension.swift in Sources */,
 				D13A4C1E2221E43A00C71F08 /* GenericWatchMessage.swift in Sources */,
+				D1B777E82244C43E003FEDF0 /* Comparable+Extensions.swift in Sources */,
 				D123EFEF21FB782C00CE8718 /* NightscoutDataMessage.swift in Sources */,
 				43794F421C2F435A00DB8B58 /* AppConstants.swift in Sources */,
 				439C39181C0E002F00D89872 /* ChartPainter.swift in Sources */,

--- a/nightguard.xcodeproj/project.pbxproj
+++ b/nightguard.xcodeproj/project.pbxproj
@@ -149,6 +149,9 @@
 		D16C8EDD22106C9300192117 /* QuickSnoozeOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16C8EDC22106C9300192117 /* QuickSnoozeOption.swift */; };
 		D16C8EDF2211047300192117 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16C8EDE2211047300192117 /* UIViewController+Extensions.swift */; };
 		D16C8EE22213022E00192117 /* UserInteractionDetectorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16C8EE12213022E00192117 /* UserInteractionDetectorWindow.swift */; };
+		D18C5D8A22293C220099D96E /* BasicStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18C5D8922293C220099D96E /* BasicStats.swift */; };
+		D18C5D8B22293C230099D96E /* BasicStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18C5D8922293C220099D96E /* BasicStats.swift */; };
+		D18C5D8C22293C230099D96E /* BasicStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18C5D8922293C220099D96E /* BasicStats.swift */; };
 		D1AEFED821FE00A200821DF6 /* AnyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AEFED721FE00A200821DF6 /* AnyConvertible.swift */; };
 		D1AEFED921FE011B00821DF6 /* AnyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AEFED721FE00A200821DF6 /* AnyConvertible.swift */; };
 		D1AEFEDA21FE011C00821DF6 /* AnyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AEFED721FE00A200821DF6 /* AnyConvertible.swift */; };
@@ -360,6 +363,7 @@
 		D16C8EDC22106C9300192117 /* QuickSnoozeOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickSnoozeOption.swift; sourceTree = "<group>"; };
 		D16C8EDE2211047300192117 /* UIViewController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extensions.swift"; sourceTree = "<group>"; };
 		D16C8EE12213022E00192117 /* UserInteractionDetectorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInteractionDetectorWindow.swift; sourceTree = "<group>"; };
+		D18C5D8922293C220099D96E /* BasicStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicStats.swift; sourceTree = "<group>"; };
 		D1AEFED721FE00A200821DF6 /* AnyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyConvertible.swift; sourceTree = "<group>"; };
 		D1BA903420D3033500A0EBD1 /* GroupedLabelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedLabelsView.swift; sourceTree = "<group>"; };
 		D1BA903720D3046600A0EBD1 /* PaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingLabel.swift; sourceTree = "<group>"; };
@@ -615,6 +619,7 @@
 				D133078721C85D4300DC6879 /* BloodSugarArrayExtension.swift */,
 				432E62DE1D10ACD200DD7978 /* Units.swift */,
 				D16C8EDC22106C9300192117 /* QuickSnoozeOption.swift */,
+				D18C5D8922293C220099D96E /* BasicStats.swift */,
 			);
 			name = domain;
 			sourceTree = "<group>";
@@ -1212,6 +1217,7 @@
 				D133078421C424A800DC6879 /* ArrayExtension.swift in Sources */,
 				D1DA7C6C21BE810900B39675 /* UIApplicationExtension.swift in Sources */,
 				D1D96CB121F85BC70035A60E /* UserDefaultsValue.swift in Sources */,
+				D18C5D8A22293C220099D96E /* BasicStats.swift in Sources */,
 				43F1E0EE1D07693300C329A2 /* AlarmRule.swift in Sources */,
 				432E62EF1D17359600DD7978 /* StringExtension.swift in Sources */,
 				D1D1623E221AAC05006F990A /* WatchSyncRequestMessage.swift in Sources */,
@@ -1241,6 +1247,7 @@
 				D1F2F57B21EF133000CEB874 /* Matrix.swift in Sources */,
 				432E62D91D0CC3AC00DD7978 /* BloodSugar.swift in Sources */,
 				437EEDC31FB716C400694EAD /* StatisticsRepository.swift in Sources */,
+				D18C5D8B22293C230099D96E /* BasicStats.swift in Sources */,
 				D133078C21C85DAA00DC6879 /* ArrayExtension.swift in Sources */,
 				432E62DA1D0CC3DE00DD7978 /* TimeService.swift in Sources */,
 				D1F2F57E21EF134400CEB874 /* RegressionHelper.swift in Sources */,
@@ -1321,6 +1328,7 @@
 				43647C0B1BFF6435004389F9 /* ExtensionDelegate.swift in Sources */,
 				43647C091BFF6435004389F9 /* InterfaceController.swift in Sources */,
 				43119B881C383CF500DD6D35 /* UIColorChanger.swift in Sources */,
+				D18C5D8C22293C230099D96E /* BasicStats.swift in Sources */,
 				43288A681D1B359D00EE3999 /* StringExtension.swift in Sources */,
 				438066FE1D21C2350021B618 /* AppMessageService.swift in Sources */,
 				437EEDC51FB7185500694EAD /* UserDefaultsRepository.swift in Sources */,
@@ -1500,7 +1508,7 @@
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
 				INFOPLIST_FILE = "nightguard WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "de.my-wan.dhe.nightguard.watchkitapp.watchkitextension";
+				PRODUCT_BUNDLE_IDENTIFIER = de.my-wan.dhe.nightguard.watchkitapp.watchkitextension;
 				PRODUCT_NAME = nightguard;
 				PROVISIONING_PROFILE = "";
 				SDKROOT = watchos;
@@ -1522,7 +1530,7 @@
 				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "iPhone Developer";
 				INFOPLIST_FILE = "nightguard WatchKit Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "de.my-wan.dhe.nightguard.watchkitapp.watchkitextension";
+				PRODUCT_BUNDLE_IDENTIFIER = de.my-wan.dhe.nightguard.watchkitapp.watchkitextension;
 				PRODUCT_NAME = nightguard;
 				PROVISIONING_PROFILE = "";
 				SDKROOT = watchos;
@@ -1546,7 +1554,7 @@
 				IBSC_MODULE = scoutwatch_WatchKit_Extension;
 				INFOPLIST_FILE = "nightguard WatchKit App/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "de.my-wan.dhe.nightguard.watchkitapp";
+				PRODUCT_BUNDLE_IDENTIFIER = de.my-wan.dhe.nightguard.watchkitapp;
 				PRODUCT_NAME = nightguard;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -1569,7 +1577,7 @@
 				IBSC_MODULE = scoutwatch_WatchKit_Extension;
 				INFOPLIST_FILE = "nightguard WatchKit App/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "de.my-wan.dhe.nightguard.watchkitapp";
+				PRODUCT_BUNDLE_IDENTIFIER = de.my-wan.dhe.nightguard.watchkitapp;
 				PRODUCT_NAME = nightguard;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
@@ -1591,7 +1599,7 @@
 				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = nightguard/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "de.my-wan.dhe.nightguard";
+				PRODUCT_BUNDLE_IDENTIFIER = de.my-wan.dhe.nightguard;
 				PRODUCT_NAME = nightguard;
 				PROVISIONING_PROFILE = "";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
@@ -1612,7 +1620,7 @@
 				ENABLE_BITCODE = YES;
 				INFOPLIST_FILE = nightguard/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "de.my-wan.dhe.nightguard";
+				PRODUCT_BUNDLE_IDENTIFIER = de.my-wan.dhe.nightguard;
 				PRODUCT_NAME = nightguard;
 				PROVISIONING_PROFILE = "";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
@@ -1628,7 +1636,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = nightguardTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "de.my-wan.dhe.nightguardTests";
+				PRODUCT_BUNDLE_IDENTIFIER = de.my-wan.dhe.nightguardTests;
 				PRODUCT_NAME = nightguard;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
@@ -1643,7 +1651,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = nightguardTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "de.my-wan.dhe.nightguardTests";
+				PRODUCT_BUNDLE_IDENTIFIER = de.my-wan.dhe.nightguardTests;
 				PRODUCT_NAME = nightguard;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
@@ -1657,7 +1665,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = nightguardUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "de.my-wan.dhe.nightguardUITests";
+				PRODUCT_BUNDLE_IDENTIFIER = de.my-wan.dhe.nightguardUITests;
 				PRODUCT_NAME = nightguard;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;
@@ -1672,7 +1680,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = nightguardUITests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "de.my-wan.dhe.nightguardUITests";
+				PRODUCT_BUNDLE_IDENTIFIER = de.my-wan.dhe.nightguardUITests;
 				PRODUCT_NAME = nightguard;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 4.0;

--- a/nightguard.xcodeproj/project.pbxproj
+++ b/nightguard.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		D1AEFED821FE00A200821DF6 /* AnyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AEFED721FE00A200821DF6 /* AnyConvertible.swift */; };
 		D1AEFED921FE011B00821DF6 /* AnyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AEFED721FE00A200821DF6 /* AnyConvertible.swift */; };
 		D1AEFEDA21FE011C00821DF6 /* AnyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1AEFED721FE00A200821DF6 /* AnyConvertible.swift */; };
+		D1B777E42243E27B003FEDF0 /* TouchReportingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B777E32243E27B003FEDF0 /* TouchReportingView.swift */; };
 		D1BA903520D3033500A0EBD1 /* GroupedLabelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1BA903420D3033500A0EBD1 /* GroupedLabelsView.swift */; };
 		D1BA903820D3046600A0EBD1 /* PaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1BA903720D3046600A0EBD1 /* PaddingLabel.swift */; };
 		D1BA903A20D304BE00A0EBD1 /* UIView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1BA903920D304BE00A0EBD1 /* UIView+Extensions.swift */; };
@@ -378,6 +379,7 @@
 		D16C8EE12213022E00192117 /* UserInteractionDetectorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInteractionDetectorWindow.swift; sourceTree = "<group>"; };
 		D18C5D8922293C220099D96E /* BasicStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicStats.swift; sourceTree = "<group>"; };
 		D1AEFED721FE00A200821DF6 /* AnyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyConvertible.swift; sourceTree = "<group>"; };
+		D1B777E32243E27B003FEDF0 /* TouchReportingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchReportingView.swift; sourceTree = "<group>"; };
 		D1BA903420D3033500A0EBD1 /* GroupedLabelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupedLabelsView.swift; sourceTree = "<group>"; };
 		D1BA903720D3046600A0EBD1 /* PaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingLabel.swift; sourceTree = "<group>"; };
 		D1BA903920D304BE00A0EBD1 /* UIView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Extensions.swift"; sourceTree = "<group>"; };
@@ -756,6 +758,7 @@
 				D1BA903720D3046600A0EBD1 /* PaddingLabel.swift */,
 				D1BA903920D304BE00A0EBD1 /* UIView+Extensions.swift */,
 				D1358AEB2237C44600D0FA87 /* XibLoadedView.swift */,
+				D1B777E32243E27B003FEDF0 /* TouchReportingView.swift */,
 			);
 			name = views;
 			sourceTree = "<group>";
@@ -1261,6 +1264,7 @@
 				D133078421C424A800DC6879 /* ArrayExtension.swift in Sources */,
 				D1DA7C6C21BE810900B39675 /* UIApplicationExtension.swift in Sources */,
 				D1D96CB121F85BC70035A60E /* UserDefaultsValue.swift in Sources */,
+				D1B777E42243E27B003FEDF0 /* TouchReportingView.swift in Sources */,
 				D18C5D8A22293C220099D96E /* BasicStats.swift in Sources */,
 				43F1E0EE1D07693300C329A2 /* AlarmRule.swift in Sources */,
 				432E62EF1D17359600DD7978 /* StringExtension.swift in Sources */,

--- a/nightguard.xcodeproj/project.pbxproj
+++ b/nightguard.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 		D16C8EDD22106C9300192117 /* QuickSnoozeOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16C8EDC22106C9300192117 /* QuickSnoozeOption.swift */; };
 		D16C8EDF2211047300192117 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16C8EDE2211047300192117 /* UIViewController+Extensions.swift */; };
 		D16C8EE22213022E00192117 /* UserInteractionDetectorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D16C8EE12213022E00192117 /* UserInteractionDetectorWindow.swift */; };
+		D17F7938224D3C500074907B /* PersistentHighViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17F7937224D3C500074907B /* PersistentHighViewController.swift */; };
 		D18C5D8A22293C220099D96E /* BasicStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18C5D8922293C220099D96E /* BasicStats.swift */; };
 		D18C5D8B22293C230099D96E /* BasicStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18C5D8922293C220099D96E /* BasicStats.swift */; };
 		D18C5D8C22293C230099D96E /* BasicStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18C5D8922293C220099D96E /* BasicStats.swift */; };
@@ -380,6 +381,7 @@
 		D16C8EDC22106C9300192117 /* QuickSnoozeOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickSnoozeOption.swift; sourceTree = "<group>"; };
 		D16C8EDE2211047300192117 /* UIViewController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Extensions.swift"; sourceTree = "<group>"; };
 		D16C8EE12213022E00192117 /* UserInteractionDetectorWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInteractionDetectorWindow.swift; sourceTree = "<group>"; };
+		D17F7937224D3C500074907B /* PersistentHighViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersistentHighViewController.swift; sourceTree = "<group>"; };
 		D18C5D8922293C220099D96E /* BasicStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicStats.swift; sourceTree = "<group>"; };
 		D1AEFED721FE00A200821DF6 /* AnyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyConvertible.swift; sourceTree = "<group>"; };
 		D1B777E32243E27B003FEDF0 /* TouchReportingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchReportingView.swift; sourceTree = "<group>"; };
@@ -751,6 +753,7 @@
 				D1EBB6A82223FF0200CE27FF /* MissedReadingsViewController.swift */,
 				D160D091220E4248002B4633 /* AlertVolumeViewController.swift */,
 				D16C8ED62210377000192117 /* SnoozeActionsViewController.swift */,
+				D17F7937224D3C500074907B /* PersistentHighViewController.swift */,
 			);
 			name = forms;
 			sourceTree = "<group>";
@@ -1273,6 +1276,7 @@
 				D1B777E42243E27B003FEDF0 /* TouchReportingView.swift in Sources */,
 				D18C5D8A22293C220099D96E /* BasicStats.swift in Sources */,
 				43F1E0EE1D07693300C329A2 /* AlarmRule.swift in Sources */,
+				D17F7938224D3C500074907B /* PersistentHighViewController.swift in Sources */,
 				432E62EF1D17359600DD7978 /* StringExtension.swift in Sources */,
 				D1D1623E221AAC05006F990A /* WatchSyncRequestMessage.swift in Sources */,
 				43F1E1011D07698000C329A2 /* AppDelegate.swift in Sources */,

--- a/nightguard/A1cView.swift
+++ b/nightguard/A1cView.swift
@@ -22,20 +22,12 @@ extension UIColor {
 
 class A1cView: BasicStatsControl {
     
-    override var pages: [StatsPage] {
+    override func createPages() -> [StatsPage] {
         return [
-            StatsPage(segmentIndex: 0, name: "A1c", value: { [weak self] in
-                CGFloat(self?.model?.a1c ?? 0)
-                }, formatter: { "\(Float($0).cleanValue)%" }, color: .clear),
-            StatsPage(segmentIndex: 1, name: "Average", value: { [weak self] in
-                CGFloat(self?.model?.averageGlucose ?? 0)
-                }, formatter: { UnitsConverter.toDisplayUnits("\($0)") + "\n\(UserDefaultsRepository.units.value.description)" },  color: .clear),
-            StatsPage(segmentIndex: 2, name: "Std Deviation", value: { [weak self] in
-                CGFloat(self?.model?.standardDeviation ?? 0)
-                }, formatter: { UnitsConverter.toDisplayUnits("\($0)") + "\n\(UserDefaultsRepository.units.value.description)" },  color: .clear),
-            StatsPage(segmentIndex: 3, name: "Coefficient of Variation", value: { [weak self] in
-                CGFloat(self?.model?.coefficientOfVariation ?? 0)
-                }, formatter: percent,  color: .clear)
+            StatsPage(name: "A1c", formattedValue: model?.formattedA1c),
+            StatsPage(name: "Average", formattedValue: model?.formattedAverageGlucose?.replacingOccurrences(of: " ", with: "\n")),
+            StatsPage(name: "Std Deviation", formattedValue: model?.formattedStandardDeviation?.replacingOccurrences(of: " ", with: "\n")),
+            StatsPage(name: "Coefficient of Variation", formattedValue: model?.formattedCoefficientOfVariation)
         ]
     }
     
@@ -65,6 +57,10 @@ class A1cView: BasicStatsControl {
         super.commonInit()
         
         diagramView.dataSource = self
+//        diagramView.separatorWidh = 8
+//        diagramView.separatorColor = .black
+//        diagramView.startAngle = .pi * 0.75
+//        diagramView.endAngle = 2 * .pi + .pi * 0.75
     }
     
     override func modelWasSet() {
@@ -81,10 +77,11 @@ class A1cView: BasicStatsControl {
 extension A1cView: SMDiagramViewDataSource {
     
     @objc func numberOfSegmentsIn(diagramView: SMDiagramView) -> Int {
-        return 1
+        return 2
     }
 
     func diagramView(_ diagramView: SMDiagramView, colorForSegmentAtIndex index: NSInteger, angle: CGFloat) -> UIColor? {
+//        return (index == 1) ? a1cColor : variationColor
         return modelColor
     }
     

--- a/nightguard/A1cView.swift
+++ b/nightguard/A1cView.swift
@@ -9,6 +9,8 @@
 import UIKit
 
 extension UIColor {
+    
+    // Creates a color-meter like UIColor by placing the given value in correspondence with its good-bad range, resulting a green color if the value is very good on that scale, a red color if is very bad or yellow & compositions with red-green if is in between
     static func redYellowGreen(for value: CGFloat, bestValue: CGFloat, worstValue: CGFloat) -> UIColor {
         if bestValue < worstValue {
             let power = max(min((worstValue - CGFloat(value)) / (worstValue - bestValue), 1), 0)
@@ -20,6 +22,9 @@ extension UIColor {
     }
 }
 
+/**
+ A stats view that displays the A1c value, the average BG value, standard deviation & variation values. It appreciates the values by giving a colored feedback to user: green - good values, yellow - okish, red - pretty bad.
+ */
 class A1cView: BasicStatsControl {
     
     override func createPages() -> [StatsPage] {

--- a/nightguard/A1cView.swift
+++ b/nightguard/A1cView.swift
@@ -1,0 +1,73 @@
+//
+//  A1cView.swift
+//  nightguard
+//
+//  Created by Florian Preknya on 3/18/19.
+//  Copyright © 2019 private. All rights reserved.
+//
+
+import UIKit
+
+class A1cView: BasicStatsControl {
+    
+    override var pages: [StatsPage] {
+        return [
+            StatsPage(segmentIndex: 0, name: "A1c", value: { [weak self] in
+                CGFloat(self?.model?.a1c ?? 0)
+                }, formatter: { "\(Float($0).cleanValue)%" }, color: .clear),
+            StatsPage(segmentIndex: 1, name: "Average", value: { [weak self] in
+                CGFloat(self?.model?.averageGlucose ?? 0)
+                }, formatter: { UnitsConverter.toDisplayUnits("\($0)") + " \(UserDefaultsRepository.units.value.description)" },  color: .clear)
+        ]
+    }
+    
+    var a1cColor: UIColor? {
+        
+        guard let currentA1cValue = model?.a1c else {
+            return nil
+        }
+        
+        let bestA1cValue: CGFloat = 5.5
+        let worstA1cValue: CGFloat = 8.5
+        
+        let power = max(min((worstA1cValue - CGFloat(currentA1cValue)) / (worstA1cValue - bestA1cValue), 1), 0)
+        let color = UIColor(red: 1 - power, green: power, blue: 0, alpha: 1)
+        
+        print(color.debugDescription)
+        
+        return color
+    }
+    
+    override func commonInit() {
+        super.commonInit()
+        
+        diagramView.dataSource = self
+    }
+    
+    override func modelWasSet() {
+        super.modelWasSet()
+        
+        diagramView.backgroundColor = a1cColor?.withAlphaComponent(0.1)
+    }
+}
+
+extension A1cView: SMDiagramViewDataSource {
+    
+    @objc func numberOfSegmentsIn(diagramView: SMDiagramView) -> Int {
+        return 1
+    }
+    
+    func diagramView(_ diagramView: SMDiagramView, colorForSegmentAtIndex index: NSInteger, angle: CGFloat) -> UIColor? {
+        
+        return a1cColor//.withAlphaComponent(0.2)
+    }
+    
+    func diagramView(_ diagramView: SMDiagramView, radiusForSegmentAtIndex index: NSInteger, proportion: CGFloat, angle: CGFloat) -> CGFloat {
+        return (diagramView.frame.size.height - 2/*diagramView.arcWidth*/) / 2
+    }
+    
+    func diagramView(_ diagramView: SMDiagramView, lineWidthForSegmentAtIndex index: NSInteger, angle: CGFloat) -> CGFloat {
+        //not called for SMDiagramViewModeSegment
+        return 2.0
+    }
+}

--- a/nightguard/AlarmRule.swift
+++ b/nightguard/AlarmRule.swift
@@ -147,11 +147,11 @@ class AlarmRule {
                 if currentReading.value < persistentHighUpperBound.value {
                     
                     // if all the previous readings (for the defined minutes are high, we'll consider it a persistent high)
-                    let lastReadingValues = bloodValues.lastXMinutes(persistentHighMinutes.value).map { Double($0.value) }
+                    let lastReadings = bloodValues.lastXMinutes(persistentHighMinutes.value)
                     
                     // we should have at least a reading in 10 minutes for considering a persistent high
-                    if !lastReadingValues.isEmpty && (lastReadingValues.count >= (persistentHighMinutes.value / 10)) {
-                        if AlarmRule.isTooHigh(Float(lastReadingValues.average)) {
+                    if !lastReadings.isEmpty && (lastReadings.count >= (persistentHighMinutes.value / 10)) {
+                        if lastReadings.allSatisfy({ AlarmRule.isTooHigh($0.value) }) {
                             return "Persistent High BG"
                         } else {
                             return nil

--- a/nightguard/Base.lproj/Main.storyboard
+++ b/nightguard/Base.lproj/Main.storyboard
@@ -262,36 +262,148 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QxI-Mz-c2E">
-                                <rect key="frame" x="8" y="711" width="398" height="86"/>
-                                <color key="backgroundColor" white="0.33333333333333331" alpha="0.50706335616438358" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="86" id="c2h-zh-E4m"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="32"/>
-                                <state key="normal" title="Snooze"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                        <integer key="value" value="4"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <action selector="doSnoozeAction:" destination="wFP-V1-Fpg" eventType="touchUpInside" id="rVO-Eo-fJe"/>
-                                </connections>
-                            </button>
-                            <containerView contentMode="scaleToFill" placeholderIntrinsicWidth="286" placeholderIntrinsicHeight="31" translatesAutoresizingMaskIntoConstraints="NO" id="4hs-Gk-Xl6">
-                                <rect key="frame" x="8" y="677.66666666666663" width="398" height="28"/>
-                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="28" id="D4S-5q-MSD"/>
-                                </constraints>
-                            </containerView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="JZR-hs-OI1">
+                                <rect key="frame" x="8" y="52" width="398" height="196"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f6k-n0-9ni">
+                                        <rect key="frame" x="0.0" y="0.0" width="398" height="104"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="240" verticalCompressionResistancePriority="1000" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="zgM-gD-e9z">
+                                                <rect key="frame" x="0.0" y="0.0" width="232.66666666666666" height="104"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="240" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="222" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="50" translatesAutoresizingMaskIntoConstraints="NO" id="aNX-u1-teT">
+                                                        <rect key="frame" x="62.666666666666686" y="0.0" width="170" height="80"/>
+                                                        <rect key="contentStretch" x="0.0" y="0.0" width="0.0" height="1"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="80" id="amT-q9-wHT"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="100"/>
+                                                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <view contentMode="scaleToFill" horizontalCompressionResistancePriority="999" placeholderIntrinsicWidth="168" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="XtI-XB-VeV" customClass="GroupedLabelsView" customModule="nightguard" customModuleProvider="target">
+                                                        <rect key="frame" x="64.666666666666686" y="84" width="168" height="20"/>
+                                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    </view>
+                                                </subviews>
+                                            </stackView>
+                                            <view contentMode="scaleToFill" horizontalHuggingPriority="230" translatesAutoresizingMaskIntoConstraints="NO" id="CuD-yp-5tf" userLabel="Spacer view">
+                                                <rect key="frame" x="232.66666666666663" y="0.0" width="50" height="104"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="32" id="gBH-rN-ZYN"/>
+                                                </constraints>
+                                            </view>
+                                            <stackView opaque="NO" contentMode="scaleToFill" placeholderIntrinsicWidth="36.5" placeholderIntrinsicHeight="104" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="6bh-Q2-ugk">
+                                                <rect key="frame" x="282.66666666666669" y="0.0" width="40" height="104"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="---" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="6" translatesAutoresizingMaskIntoConstraints="NO" id="7OG-w8-xXQ">
+                                                        <rect key="frame" x="0.0" y="0.0" width="40" height="30"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="30" id="4zp-9Q-nET"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="30"/>
+                                                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="6" translatesAutoresizingMaskIntoConstraints="NO" id="SLx-m6-8iP">
+                                                        <rect key="frame" x="0.0" y="42" width="40" height="30"/>
+                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
+                                                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0.0U" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="6" translatesAutoresizingMaskIntoConstraints="NO" id="sxg-9W-FFR">
+                                                        <rect key="frame" x="0.0" y="84" width="40" height="20"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="20" id="qMv-Ka-vKS"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <color key="textColor" red="0.9651752629" green="0.96381590189999999" blue="0.98756055269999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="7OG-w8-xXQ" firstAttribute="height" secondItem="SLx-m6-8iP" secondAttribute="height" id="R2M-0W-Dp7"/>
+                                                    <constraint firstItem="SLx-m6-8iP" firstAttribute="height" secondItem="7OG-w8-xXQ" secondAttribute="height" id="Ran-G8-Gpb"/>
+                                                </constraints>
+                                                <variation key="default">
+                                                    <mask key="constraints">
+                                                        <exclude reference="R2M-0W-Dp7"/>
+                                                    </mask>
+                                                </variation>
+                                            </stackView>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MZQ-Pu-l1x" userLabel="Spacer view">
+                                                <rect key="frame" x="322.66666666666669" y="0.0" width="16" height="104"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="16" id="nJc-UK-Xfm"/>
+                                                </constraints>
+                                            </view>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="jkn-bn-vCC">
+                                                <rect key="frame" x="338.66666666666669" y="0.0" width="59.333333333333314" height="104"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="--:--" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="6" translatesAutoresizingMaskIntoConstraints="NO" id="YvM-WS-hyk">
+                                                        <rect key="frame" x="0.0" y="0.0" width="59.333333333333336" height="30"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="30" id="tWi-VL-fcI"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="27"/>
+                                                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0min" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="6" translatesAutoresizingMaskIntoConstraints="NO" id="FFv-EO-ylg">
+                                                        <rect key="frame" x="0.0" y="42" width="59.333333333333336" height="30"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="27"/>
+                                                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="751" text="100%" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="6" translatesAutoresizingMaskIntoConstraints="NO" id="3ZI-eY-05Z">
+                                                        <rect key="frame" x="0.0" y="84" width="59.333333333333336" height="20"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="20" id="fkf-op-N2S"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="FFv-EO-ylg" firstAttribute="height" secondItem="YvM-WS-hyk" secondAttribute="height" id="Jcl-tb-fqL"/>
+                                                    <constraint firstItem="YvM-WS-hyk" firstAttribute="height" secondItem="FFv-EO-ylg" secondAttribute="height" id="Owo-WA-V4l"/>
+                                                </constraints>
+                                                <variation key="default">
+                                                    <mask key="constraints">
+                                                        <exclude reference="Owo-WA-V4l"/>
+                                                    </mask>
+                                                </variation>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
+                                    <label hidden="YES" opaque="NO" userInteractionEnabled="NO" alpha="0.5" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A1C: 6.4, in range: 85%" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9N5-p0-4wp">
+                                        <rect key="frame" x="0.0" y="110" width="398" height="0.0"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <view contentMode="scaleToFill" placeholderIntrinsicWidth="398" placeholderIntrinsicHeight="80" translatesAutoresizingMaskIntoConstraints="NO" id="8KP-K7-ZDM" customClass="BasicStatsPanelView" customModule="nightguard" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="116" width="398" height="80"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="70" id="mEj-5g-aa7"/>
+                                        </constraints>
+                                        <variation key="default">
+                                            <mask key="constraints">
+                                                <exclude reference="mEj-5g-aa7"/>
+                                            </mask>
+                                        </variation>
+                                    </view>
+                                </subviews>
+                            </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dot-Yq-gkc" customClass="SKView">
-                                <rect key="frame" x="0.0" y="200" width="414" height="456"/>
+                                <rect key="frame" x="0.0" y="256" width="414" height="414"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ifJ-Wp-aAP">
-                                        <rect key="frame" x="356" y="390" width="50" height="50"/>
+                                        <rect key="frame" x="356" y="348" width="50" height="50"/>
                                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="50" id="5To-yk-NNp"/>
@@ -309,8 +421,33 @@
                                     <constraint firstAttribute="bottom" secondItem="ifJ-Wp-aAP" secondAttribute="bottom" constant="16" id="mNB-Ks-HOD"/>
                                 </constraints>
                             </view>
+                            <containerView contentMode="scaleToFill" placeholderIntrinsicWidth="286" placeholderIntrinsicHeight="31" translatesAutoresizingMaskIntoConstraints="NO" id="4hs-Gk-Xl6">
+                                <rect key="frame" x="8" y="691.66666666666663" width="398" height="28"/>
+                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="28" id="D4S-5q-MSD"/>
+                                </constraints>
+                            </containerView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QxI-Mz-c2E">
+                                <rect key="frame" x="8" y="725" width="398" height="80"/>
+                                <color key="backgroundColor" white="0.33333333333333331" alpha="0.50706335616438358" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="80" id="c2h-zh-E4m"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="32"/>
+                                <state key="normal" title="Snooze"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="4"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="doSnoozeAction:" destination="wFP-V1-Fpg" eventType="touchUpInside" id="rVO-Eo-fJe"/>
+                                </connections>
+                            </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1rF-Wm-FbJ">
-                                <rect key="frame" x="119.33333333333333" y="208" width="175.33333333333337" height="23.666666666666657"/>
+                                <rect key="frame" x="119.33333333333333" y="264" width="175.33333333333337" height="23.666666666666686"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="❌ Some error message..." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tea-wl-rpX">
                                         <rect key="frame" x="8" y="3.9999999999999991" width="159.33333333333334" height="15.666666666666664"/>
@@ -333,126 +470,6 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f6k-n0-9ni">
-                                <rect key="frame" x="8" y="52" width="398" height="104"/>
-                                <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="240" verticalCompressionResistancePriority="1000" axis="vertical" alignment="bottom" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="zgM-gD-e9z">
-                                        <rect key="frame" x="0.0" y="0.0" width="232.66666666666666" height="104"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="240" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="222" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="50" translatesAutoresizingMaskIntoConstraints="NO" id="aNX-u1-teT">
-                                                <rect key="frame" x="62.666666666666686" y="0.0" width="170" height="80"/>
-                                                <rect key="contentStretch" x="0.0" y="0.0" width="0.0" height="1"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="80" id="amT-q9-wHT"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="100"/>
-                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <view contentMode="scaleToFill" horizontalCompressionResistancePriority="999" placeholderIntrinsicWidth="168" placeholderIntrinsicHeight="20" translatesAutoresizingMaskIntoConstraints="NO" id="XtI-XB-VeV" customClass="GroupedLabelsView" customModule="nightguard" customModuleProvider="target">
-                                                <rect key="frame" x="64.666666666666686" y="84" width="168" height="20"/>
-                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            </view>
-                                        </subviews>
-                                    </stackView>
-                                    <view contentMode="scaleToFill" horizontalHuggingPriority="230" translatesAutoresizingMaskIntoConstraints="NO" id="CuD-yp-5tf" userLabel="Spacer view">
-                                        <rect key="frame" x="232.66666666666663" y="0.0" width="50" height="104"/>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="32" id="gBH-rN-ZYN"/>
-                                        </constraints>
-                                    </view>
-                                    <stackView opaque="NO" contentMode="scaleToFill" placeholderIntrinsicWidth="36.5" placeholderIntrinsicHeight="104" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="6bh-Q2-ugk">
-                                        <rect key="frame" x="282.66666666666669" y="0.0" width="40" height="104"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="---" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="6" translatesAutoresizingMaskIntoConstraints="NO" id="7OG-w8-xXQ">
-                                                <rect key="frame" x="0.0" y="0.0" width="40" height="30"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="30" id="4zp-9Q-nET"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
-                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="6" translatesAutoresizingMaskIntoConstraints="NO" id="SLx-m6-8iP">
-                                                <rect key="frame" x="0.0" y="42" width="40" height="30"/>
-                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="30"/>
-                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0.0U" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="6" translatesAutoresizingMaskIntoConstraints="NO" id="sxg-9W-FFR">
-                                                <rect key="frame" x="0.0" y="84" width="40" height="20"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="20" id="qMv-Ka-vKS"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <color key="textColor" red="0.9651752629" green="0.96381590189999999" blue="0.98756055269999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <constraints>
-                                            <constraint firstItem="7OG-w8-xXQ" firstAttribute="height" secondItem="SLx-m6-8iP" secondAttribute="height" id="R2M-0W-Dp7"/>
-                                            <constraint firstItem="SLx-m6-8iP" firstAttribute="height" secondItem="7OG-w8-xXQ" secondAttribute="height" id="Ran-G8-Gpb"/>
-                                        </constraints>
-                                        <variation key="default">
-                                            <mask key="constraints">
-                                                <exclude reference="R2M-0W-Dp7"/>
-                                            </mask>
-                                        </variation>
-                                    </stackView>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MZQ-Pu-l1x" userLabel="Spacer view">
-                                        <rect key="frame" x="322.66666666666669" y="0.0" width="16" height="104"/>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="16" id="nJc-UK-Xfm"/>
-                                        </constraints>
-                                    </view>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="jkn-bn-vCC">
-                                        <rect key="frame" x="338.66666666666669" y="0.0" width="59.333333333333314" height="104"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="--:--" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="6" translatesAutoresizingMaskIntoConstraints="NO" id="YvM-WS-hyk">
-                                                <rect key="frame" x="0.0" y="0.0" width="59.333333333333336" height="30"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="30" id="tWi-VL-fcI"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="27"/>
-                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0min" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="6" translatesAutoresizingMaskIntoConstraints="NO" id="FFv-EO-ylg">
-                                                <rect key="frame" x="0.0" y="42" width="59.333333333333336" height="30"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="27"/>
-                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="751" text="100%" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="6" translatesAutoresizingMaskIntoConstraints="NO" id="3ZI-eY-05Z">
-                                                <rect key="frame" x="0.0" y="84" width="59.333333333333336" height="20"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="20" id="fkf-op-N2S"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <constraints>
-                                            <constraint firstItem="FFv-EO-ylg" firstAttribute="height" secondItem="YvM-WS-hyk" secondAttribute="height" id="Jcl-tb-fqL"/>
-                                            <constraint firstItem="YvM-WS-hyk" firstAttribute="height" secondItem="FFv-EO-ylg" secondAttribute="height" id="Owo-WA-V4l"/>
-                                        </constraints>
-                                        <variation key="default">
-                                            <mask key="constraints">
-                                                <exclude reference="Owo-WA-V4l"/>
-                                            </mask>
-                                        </variation>
-                                    </stackView>
-                                </subviews>
-                            </stackView>
-                            <label opaque="NO" userInteractionEnabled="NO" alpha="0.5" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A1C: 6.4, in range: 85%" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9N5-p0-4wp">
-                                <rect key="frame" x="70.666666666666657" y="168" width="335.33333333333337" height="24"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                         </subviews>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <accessibility key="accessibilityConfiguration" label="Preferences"/>
@@ -462,30 +479,21 @@
                             <constraint firstItem="1rF-Wm-FbJ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="tZK-nt-kLA" secondAttribute="leading" constant="16" id="8PW-cQ-aAZ"/>
                             <constraint firstItem="1rF-Wm-FbJ" firstAttribute="top" secondItem="dot-Yq-gkc" secondAttribute="top" constant="8" id="Ego-v1-CFB"/>
                             <constraint firstItem="QxI-Mz-c2E" firstAttribute="leading" secondItem="tZK-nt-kLA" secondAttribute="leading" constant="8" id="Klv-Ef-br1"/>
+                            <constraint firstItem="JZR-hs-OI1" firstAttribute="top" secondItem="tZK-nt-kLA" secondAttribute="top" constant="8" id="N6m-xR-3v6"/>
                             <constraint firstItem="dot-Yq-gkc" firstAttribute="leading" secondItem="tZK-nt-kLA" secondAttribute="leading" id="OWA-mS-SW6"/>
+                            <constraint firstItem="tZK-nt-kLA" firstAttribute="trailing" secondItem="JZR-hs-OI1" secondAttribute="trailing" constant="8" id="Wf4-50-I6h"/>
                             <constraint firstItem="1rF-Wm-FbJ" firstAttribute="centerX" secondItem="kaq-Fc-h0j" secondAttribute="centerX" id="WuA-to-AEA"/>
-                            <constraint firstItem="dot-Yq-gkc" firstAttribute="top" secondItem="9N5-p0-4wp" secondAttribute="bottom" constant="8" id="YZh-gM-rCr"/>
-                            <constraint firstItem="QxI-Mz-c2E" firstAttribute="bottom" secondItem="tZK-nt-kLA" secondAttribute="bottom" constant="-16" id="YpJ-Qg-KCD"/>
+                            <constraint firstItem="QxI-Mz-c2E" firstAttribute="bottom" secondItem="tZK-nt-kLA" secondAttribute="bottom" constant="-8" id="YpJ-Qg-KCD"/>
                             <constraint firstItem="QxI-Mz-c2E" firstAttribute="top" secondItem="dot-Yq-gkc" secondAttribute="bottom" constant="55" id="Yvm-s9-X5C"/>
-                            <constraint firstItem="9N5-p0-4wp" firstAttribute="top" secondItem="f6k-n0-9ni" secondAttribute="bottom" constant="12" id="ZlJ-xR-JHp"/>
-                            <constraint firstItem="f6k-n0-9ni" firstAttribute="leading" secondItem="kaq-Fc-h0j" secondAttribute="leading" constant="8" id="a29-lU-eI5"/>
-                            <constraint firstItem="9N5-p0-4wp" firstAttribute="trailing" secondItem="jkn-bn-vCC" secondAttribute="trailing" id="b4j-bq-3jd"/>
                             <constraint firstItem="tZK-nt-kLA" firstAttribute="trailing" secondItem="4hs-Gk-Xl6" secondAttribute="trailing" constant="8" id="dBA-IS-1Rm"/>
                             <constraint firstItem="tZK-nt-kLA" firstAttribute="trailing" secondItem="QxI-Mz-c2E" secondAttribute="trailing" constant="8" id="ehu-vO-rie"/>
                             <constraint firstItem="4hs-Gk-Xl6" firstAttribute="leading" secondItem="tZK-nt-kLA" secondAttribute="leading" constant="8" id="gri-69-JHl"/>
-                            <constraint firstItem="dot-Yq-gkc" firstAttribute="top" secondItem="f6k-n0-9ni" secondAttribute="bottom" constant="56" id="j6b-Wv-i5b"/>
-                            <constraint firstAttribute="trailing" secondItem="f6k-n0-9ni" secondAttribute="trailing" constant="8" id="qSw-fc-s74"/>
-                            <constraint firstItem="aNX-u1-teT" firstAttribute="leading" secondItem="9N5-p0-4wp" secondAttribute="leading" id="t3f-VQ-S6Q"/>
                             <constraint firstItem="dot-Yq-gkc" firstAttribute="trailing" secondItem="tZK-nt-kLA" secondAttribute="trailing" id="tbn-eR-7gt"/>
                             <constraint firstItem="4hs-Gk-Xl6" firstAttribute="trailing" secondItem="QxI-Mz-c2E" secondAttribute="trailing" id="uev-8J-O3X"/>
-                            <constraint firstItem="f6k-n0-9ni" firstAttribute="top" secondItem="tZK-nt-kLA" secondAttribute="top" constant="8" id="ujv-hY-vaQ"/>
+                            <constraint firstItem="dot-Yq-gkc" firstAttribute="top" secondItem="JZR-hs-OI1" secondAttribute="bottom" constant="8" id="vPN-8e-kWZ"/>
+                            <constraint firstItem="JZR-hs-OI1" firstAttribute="leading" secondItem="tZK-nt-kLA" secondAttribute="leading" constant="8" id="zBV-oh-lrB"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="tZK-nt-kLA"/>
-                        <variation key="default">
-                            <mask key="constraints">
-                                <exclude reference="j6b-Wv-i5b"/>
-                            </mask>
-                        </variation>
                     </view>
                     <tabBarItem key="tabBarItem" title="Main" image="Main" id="cAJ-FQ-kWE"/>
                     <navigationItem key="navigationItem" id="h66-MF-LkU"/>
@@ -505,6 +513,7 @@
                         <outlet property="snoozeButton" destination="QxI-Mz-c2E" id="fvE-ps-o54"/>
                         <outlet property="spriteKitView" destination="dot-Yq-gkc" id="VQK-0m-Y6R"/>
                         <outlet property="statsLabel" destination="9N5-p0-4wp" id="kRH-XA-51A"/>
+                        <outlet property="statsPanelView" destination="8KP-K7-ZDM" id="TEl-Rt-zAb"/>
                         <outlet property="timeLabel" destination="YvM-WS-hyk" id="t6A-d4-mVH"/>
                         <outlet property="volumeContainerView" destination="4hs-Gk-Xl6" id="0Wm-7G-jj6"/>
                     </connections>

--- a/nightguard/Base.lproj/Main.storyboard
+++ b/nightguard/Base.lproj/Main.storyboard
@@ -279,7 +279,7 @@
                                     <action selector="doSnoozeAction:" destination="wFP-V1-Fpg" eventType="touchUpInside" id="rVO-Eo-fJe"/>
                                 </connections>
                             </button>
-                            <containerView contentMode="scaleToFill" ambiguous="YES" placeholderIntrinsicWidth="286" placeholderIntrinsicHeight="31" translatesAutoresizingMaskIntoConstraints="NO" id="4hs-Gk-Xl6">
+                            <containerView contentMode="scaleToFill" placeholderIntrinsicWidth="286" placeholderIntrinsicHeight="31" translatesAutoresizingMaskIntoConstraints="NO" id="4hs-Gk-Xl6">
                                 <rect key="frame" x="8" y="677.66666666666663" width="398" height="28"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -288,10 +288,10 @@
                                 </constraints>
                             </containerView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dot-Yq-gkc" customClass="SKView">
-                                <rect key="frame" x="0.0" y="172" width="414" height="484"/>
+                                <rect key="frame" x="0.0" y="200" width="414" height="456"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ifJ-Wp-aAP">
-                                        <rect key="frame" x="356" y="418" width="50" height="50"/>
+                                        <rect key="frame" x="356" y="390" width="50" height="50"/>
                                         <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="50" id="5To-yk-NNp"/>
@@ -310,7 +310,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1rF-Wm-FbJ">
-                                <rect key="frame" x="119.33333333333333" y="180" width="175.33333333333337" height="23.666666666666657"/>
+                                <rect key="frame" x="119.33333333333333" y="208" width="175.33333333333337" height="23.666666666666657"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="❌ Some error message..." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tea-wl-rpX">
                                         <rect key="frame" x="8" y="3.9999999999999991" width="159.33333333333334" height="15.666666666666664"/>
@@ -447,29 +447,45 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
+                            <label opaque="NO" userInteractionEnabled="NO" alpha="0.5" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A1C: 6.4, in range: 85%" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9N5-p0-4wp">
+                                <rect key="frame" x="70.666666666666657" y="168" width="335.33333333333337" height="24"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <accessibility key="accessibilityConfiguration" label="Preferences"/>
                         <constraints>
+                            <constraint firstItem="QxI-Mz-c2E" firstAttribute="top" secondItem="4hs-Gk-Xl6" secondAttribute="bottom" constant="5.3333333333333712" id="2Vj-Ue-SMm"/>
                             <constraint firstItem="tZK-nt-kLA" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1rF-Wm-FbJ" secondAttribute="trailing" constant="16" id="48s-0a-W8r"/>
-                            <constraint firstItem="1rF-Wm-FbJ" firstAttribute="top" secondItem="f6k-n0-9ni" secondAttribute="bottom" constant="24" id="4we-MA-ydm"/>
                             <constraint firstItem="1rF-Wm-FbJ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="tZK-nt-kLA" secondAttribute="leading" constant="16" id="8PW-cQ-aAZ"/>
+                            <constraint firstItem="1rF-Wm-FbJ" firstAttribute="top" secondItem="dot-Yq-gkc" secondAttribute="top" constant="8" id="Ego-v1-CFB"/>
                             <constraint firstItem="QxI-Mz-c2E" firstAttribute="leading" secondItem="tZK-nt-kLA" secondAttribute="leading" constant="8" id="Klv-Ef-br1"/>
                             <constraint firstItem="dot-Yq-gkc" firstAttribute="leading" secondItem="tZK-nt-kLA" secondAttribute="leading" id="OWA-mS-SW6"/>
                             <constraint firstItem="1rF-Wm-FbJ" firstAttribute="centerX" secondItem="kaq-Fc-h0j" secondAttribute="centerX" id="WuA-to-AEA"/>
+                            <constraint firstItem="dot-Yq-gkc" firstAttribute="top" secondItem="9N5-p0-4wp" secondAttribute="bottom" constant="8" id="YZh-gM-rCr"/>
                             <constraint firstItem="QxI-Mz-c2E" firstAttribute="bottom" secondItem="tZK-nt-kLA" secondAttribute="bottom" constant="-16" id="YpJ-Qg-KCD"/>
                             <constraint firstItem="QxI-Mz-c2E" firstAttribute="top" secondItem="dot-Yq-gkc" secondAttribute="bottom" constant="55" id="Yvm-s9-X5C"/>
+                            <constraint firstItem="9N5-p0-4wp" firstAttribute="top" secondItem="f6k-n0-9ni" secondAttribute="bottom" constant="12" id="ZlJ-xR-JHp"/>
                             <constraint firstItem="f6k-n0-9ni" firstAttribute="leading" secondItem="kaq-Fc-h0j" secondAttribute="leading" constant="8" id="a29-lU-eI5"/>
+                            <constraint firstItem="9N5-p0-4wp" firstAttribute="trailing" secondItem="jkn-bn-vCC" secondAttribute="trailing" id="b4j-bq-3jd"/>
                             <constraint firstItem="tZK-nt-kLA" firstAttribute="trailing" secondItem="4hs-Gk-Xl6" secondAttribute="trailing" constant="8" id="dBA-IS-1Rm"/>
                             <constraint firstItem="tZK-nt-kLA" firstAttribute="trailing" secondItem="QxI-Mz-c2E" secondAttribute="trailing" constant="8" id="ehu-vO-rie"/>
                             <constraint firstItem="4hs-Gk-Xl6" firstAttribute="leading" secondItem="tZK-nt-kLA" secondAttribute="leading" constant="8" id="gri-69-JHl"/>
-                            <constraint firstItem="dot-Yq-gkc" firstAttribute="top" secondItem="f6k-n0-9ni" secondAttribute="bottom" constant="16" id="j6b-Wv-i5b"/>
+                            <constraint firstItem="dot-Yq-gkc" firstAttribute="top" secondItem="f6k-n0-9ni" secondAttribute="bottom" constant="56" id="j6b-Wv-i5b"/>
                             <constraint firstAttribute="trailing" secondItem="f6k-n0-9ni" secondAttribute="trailing" constant="8" id="qSw-fc-s74"/>
+                            <constraint firstItem="aNX-u1-teT" firstAttribute="leading" secondItem="9N5-p0-4wp" secondAttribute="leading" id="t3f-VQ-S6Q"/>
                             <constraint firstItem="dot-Yq-gkc" firstAttribute="trailing" secondItem="tZK-nt-kLA" secondAttribute="trailing" id="tbn-eR-7gt"/>
                             <constraint firstItem="4hs-Gk-Xl6" firstAttribute="trailing" secondItem="QxI-Mz-c2E" secondAttribute="trailing" id="uev-8J-O3X"/>
                             <constraint firstItem="f6k-n0-9ni" firstAttribute="top" secondItem="tZK-nt-kLA" secondAttribute="top" constant="8" id="ujv-hY-vaQ"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="tZK-nt-kLA"/>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="j6b-Wv-i5b"/>
+                            </mask>
+                        </variation>
                     </view>
                     <tabBarItem key="tabBarItem" title="Main" image="Main" id="cAJ-FQ-kWE"/>
                     <navigationItem key="navigationItem" id="h66-MF-LkU"/>
@@ -488,6 +504,7 @@
                         <outlet property="rawValuesPanel" destination="XtI-XB-VeV" id="1T6-VA-eJr"/>
                         <outlet property="snoozeButton" destination="QxI-Mz-c2E" id="fvE-ps-o54"/>
                         <outlet property="spriteKitView" destination="dot-Yq-gkc" id="VQK-0m-Y6R"/>
+                        <outlet property="statsLabel" destination="9N5-p0-4wp" id="kRH-XA-51A"/>
                         <outlet property="timeLabel" destination="YvM-WS-hyk" id="t6A-d4-mVH"/>
                         <outlet property="volumeContainerView" destination="4hs-Gk-Xl6" id="0Wm-7G-jj6"/>
                     </connections>

--- a/nightguard/Base.lproj/Main.storyboard
+++ b/nightguard/Base.lproj/Main.storyboard
@@ -379,21 +379,15 @@
                                             </stackView>
                                         </subviews>
                                     </stackView>
-                                    <label hidden="YES" opaque="NO" userInteractionEnabled="NO" alpha="0.5" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="A1C: 6.4, in range: 85%" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9N5-p0-4wp">
-                                        <rect key="frame" x="0.0" y="110" width="398" height="0.0"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
                                     <view contentMode="scaleToFill" placeholderIntrinsicWidth="398" placeholderIntrinsicHeight="80" translatesAutoresizingMaskIntoConstraints="NO" id="8KP-K7-ZDM" customClass="BasicStatsPanelView" customModule="nightguard" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="116" width="398" height="80"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="70" id="mEj-5g-aa7"/>
+                                            <constraint firstAttribute="height" priority="750" constant="80" id="i40-16-jLK"/>
                                         </constraints>
                                         <variation key="default">
                                             <mask key="constraints">
-                                                <exclude reference="mEj-5g-aa7"/>
+                                                <exclude reference="i40-16-jLK"/>
                                             </mask>
                                         </variation>
                                     </view>
@@ -512,7 +506,6 @@
                         <outlet property="rawValuesPanel" destination="XtI-XB-VeV" id="1T6-VA-eJr"/>
                         <outlet property="snoozeButton" destination="QxI-Mz-c2E" id="fvE-ps-o54"/>
                         <outlet property="spriteKitView" destination="dot-Yq-gkc" id="VQK-0m-Y6R"/>
-                        <outlet property="statsLabel" destination="9N5-p0-4wp" id="kRH-XA-51A"/>
                         <outlet property="statsPanelView" destination="8KP-K7-ZDM" id="TEl-Rt-zAb"/>
                         <outlet property="timeLabel" destination="YvM-WS-hyk" id="t6A-d4-mVH"/>
                         <outlet property="volumeContainerView" destination="4hs-Gk-Xl6" id="0Wm-7G-jj6"/>

--- a/nightguard/Base.lproj/Main.storyboard
+++ b/nightguard/Base.lproj/Main.storyboard
@@ -262,8 +262,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="JZR-hs-OI1">
-                                <rect key="frame" x="8" y="52" width="398" height="196"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="JZR-hs-OI1">
+                                <rect key="frame" x="8" y="52" width="398" height="200"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f6k-n0-9ni">
                                         <rect key="frame" x="0.0" y="0.0" width="398" height="104"/>
@@ -380,7 +380,7 @@
                                         </subviews>
                                     </stackView>
                                     <view contentMode="scaleToFill" placeholderIntrinsicWidth="398" placeholderIntrinsicHeight="80" translatesAutoresizingMaskIntoConstraints="NO" id="8KP-K7-ZDM" customClass="BasicStatsPanelView" customModule="nightguard" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="116" width="398" height="80"/>
+                                        <rect key="frame" x="0.0" y="120" width="398" height="80"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" priority="750" constant="80" id="i40-16-jLK"/>
@@ -394,42 +394,17 @@
                                 </subviews>
                             </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dot-Yq-gkc" customClass="SKView">
-                                <rect key="frame" x="0.0" y="256" width="414" height="414"/>
-                                <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ifJ-Wp-aAP">
-                                        <rect key="frame" x="356" y="348" width="50" height="50"/>
-                                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="50" id="5To-yk-NNp"/>
-                                            <constraint firstAttribute="width" secondItem="ifJ-Wp-aAP" secondAttribute="height" multiplier="1:1" id="ZWR-Tw-wX8"/>
-                                        </constraints>
-                                        <state key="normal" image="Nightscout"/>
-                                        <connections>
-                                            <segue destination="KJF-Ig-XKW" kind="show" id="oM9-fP-iXI"/>
-                                        </connections>
-                                    </button>
-                                </subviews>
+                                <rect key="frame" x="0.0" y="268" width="414" height="441"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
-                                <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="ifJ-Wp-aAP" secondAttribute="trailing" constant="8" id="lX6-Wa-Dx8"/>
-                                    <constraint firstAttribute="bottom" secondItem="ifJ-Wp-aAP" secondAttribute="bottom" constant="16" id="mNB-Ks-HOD"/>
-                                </constraints>
                             </view>
-                            <containerView contentMode="scaleToFill" placeholderIntrinsicWidth="286" placeholderIntrinsicHeight="31" translatesAutoresizingMaskIntoConstraints="NO" id="4hs-Gk-Xl6">
-                                <rect key="frame" x="8" y="691.66666666666663" width="398" height="28"/>
-                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="28" id="D4S-5q-MSD"/>
-                                </constraints>
-                            </containerView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QxI-Mz-c2E">
                                 <rect key="frame" x="8" y="725" width="398" height="80"/>
                                 <color key="backgroundColor" white="0.33333333333333331" alpha="0.50706335616438358" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="80" id="c2h-zh-E4m"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="32"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="27"/>
+                                <inset key="titleEdgeInsets" minX="48" minY="0.0" maxX="48" maxY="0.0"/>
                                 <state key="normal" title="Snooze"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -441,7 +416,7 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1rF-Wm-FbJ">
-                                <rect key="frame" x="119.33333333333333" y="264" width="175.33333333333337" height="23.666666666666686"/>
+                                <rect key="frame" x="119.33333333333333" y="276" width="175.33333333333337" height="23.666666666666686"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="❌ Some error message..." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tea-wl-rpX">
                                         <rect key="frame" x="8" y="3.9999999999999991" width="159.33333333333334" height="15.666666666666664"/>
@@ -464,27 +439,49 @@
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
                             </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="G6P-2g-zF8">
+                                <rect key="frame" x="350" y="717" width="64" height="64"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ifJ-Wp-aAP">
+                                        <rect key="frame" x="8" y="8" width="48" height="48"/>
+                                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="48" id="5To-yk-NNp"/>
+                                            <constraint firstAttribute="width" secondItem="ifJ-Wp-aAP" secondAttribute="height" multiplier="1:1" id="ZWR-Tw-wX8"/>
+                                        </constraints>
+                                        <state key="normal" image="Nightscout"/>
+                                        <connections>
+                                            <segue destination="KJF-Ig-XKW" kind="show" id="oM9-fP-iXI"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="ifJ-Wp-aAP" firstAttribute="centerY" secondItem="G6P-2g-zF8" secondAttribute="centerY" id="8xr-OM-u4H"/>
+                                    <constraint firstItem="ifJ-Wp-aAP" firstAttribute="centerX" secondItem="G6P-2g-zF8" secondAttribute="centerX" id="Tvu-ww-hRc"/>
+                                    <constraint firstAttribute="width" secondItem="G6P-2g-zF8" secondAttribute="height" multiplier="1:1" id="Zn2-N1-NYh"/>
+                                    <constraint firstAttribute="width" constant="64" id="rTD-vZ-shN"/>
+                                </constraints>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <accessibility key="accessibilityConfiguration" label="Preferences"/>
                         <constraints>
-                            <constraint firstItem="QxI-Mz-c2E" firstAttribute="top" secondItem="4hs-Gk-Xl6" secondAttribute="bottom" constant="5.3333333333333712" id="2Vj-Ue-SMm"/>
                             <constraint firstItem="tZK-nt-kLA" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1rF-Wm-FbJ" secondAttribute="trailing" constant="16" id="48s-0a-W8r"/>
                             <constraint firstItem="1rF-Wm-FbJ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="tZK-nt-kLA" secondAttribute="leading" constant="16" id="8PW-cQ-aAZ"/>
                             <constraint firstItem="1rF-Wm-FbJ" firstAttribute="top" secondItem="dot-Yq-gkc" secondAttribute="top" constant="8" id="Ego-v1-CFB"/>
                             <constraint firstItem="QxI-Mz-c2E" firstAttribute="leading" secondItem="tZK-nt-kLA" secondAttribute="leading" constant="8" id="Klv-Ef-br1"/>
+                            <constraint firstItem="G6P-2g-zF8" firstAttribute="centerY" secondItem="QxI-Mz-c2E" secondAttribute="centerY" constant="-16" id="L2o-wC-c8X"/>
                             <constraint firstItem="JZR-hs-OI1" firstAttribute="top" secondItem="tZK-nt-kLA" secondAttribute="top" constant="8" id="N6m-xR-3v6"/>
                             <constraint firstItem="dot-Yq-gkc" firstAttribute="leading" secondItem="tZK-nt-kLA" secondAttribute="leading" id="OWA-mS-SW6"/>
                             <constraint firstItem="tZK-nt-kLA" firstAttribute="trailing" secondItem="JZR-hs-OI1" secondAttribute="trailing" constant="8" id="Wf4-50-I6h"/>
                             <constraint firstItem="1rF-Wm-FbJ" firstAttribute="centerX" secondItem="kaq-Fc-h0j" secondAttribute="centerX" id="WuA-to-AEA"/>
                             <constraint firstItem="QxI-Mz-c2E" firstAttribute="bottom" secondItem="tZK-nt-kLA" secondAttribute="bottom" constant="-8" id="YpJ-Qg-KCD"/>
-                            <constraint firstItem="QxI-Mz-c2E" firstAttribute="top" secondItem="dot-Yq-gkc" secondAttribute="bottom" constant="55" id="Yvm-s9-X5C"/>
-                            <constraint firstItem="tZK-nt-kLA" firstAttribute="trailing" secondItem="4hs-Gk-Xl6" secondAttribute="trailing" constant="8" id="dBA-IS-1Rm"/>
+                            <constraint firstItem="QxI-Mz-c2E" firstAttribute="top" secondItem="dot-Yq-gkc" secondAttribute="bottom" constant="16" id="Yvm-s9-X5C"/>
                             <constraint firstItem="tZK-nt-kLA" firstAttribute="trailing" secondItem="QxI-Mz-c2E" secondAttribute="trailing" constant="8" id="ehu-vO-rie"/>
-                            <constraint firstItem="4hs-Gk-Xl6" firstAttribute="leading" secondItem="tZK-nt-kLA" secondAttribute="leading" constant="8" id="gri-69-JHl"/>
+                            <constraint firstItem="G6P-2g-zF8" firstAttribute="trailing" secondItem="tZK-nt-kLA" secondAttribute="trailing" id="gQs-7v-D1g"/>
                             <constraint firstItem="dot-Yq-gkc" firstAttribute="trailing" secondItem="tZK-nt-kLA" secondAttribute="trailing" id="tbn-eR-7gt"/>
-                            <constraint firstItem="4hs-Gk-Xl6" firstAttribute="trailing" secondItem="QxI-Mz-c2E" secondAttribute="trailing" id="uev-8J-O3X"/>
-                            <constraint firstItem="dot-Yq-gkc" firstAttribute="top" secondItem="JZR-hs-OI1" secondAttribute="bottom" constant="8" id="vPN-8e-kWZ"/>
+                            <constraint firstItem="dot-Yq-gkc" firstAttribute="top" secondItem="JZR-hs-OI1" secondAttribute="bottom" constant="16" id="vPN-8e-kWZ"/>
                             <constraint firstItem="JZR-hs-OI1" firstAttribute="leading" secondItem="tZK-nt-kLA" secondAttribute="leading" constant="8" id="zBV-oh-lrB"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="tZK-nt-kLA"/>
@@ -503,17 +500,17 @@
                         <outlet property="iobLabel" destination="sxg-9W-FFR" id="DEM-gT-C3j"/>
                         <outlet property="lastUpdateLabel" destination="FFv-EO-ylg" id="KqE-n5-OYo"/>
                         <outlet property="nightscoutButton" destination="ifJ-Wp-aAP" id="MHE-ed-Fhw"/>
+                        <outlet property="nightscoutButtonPanelView" destination="G6P-2g-zF8" id="d37-ZH-Zql"/>
                         <outlet property="rawValuesPanel" destination="XtI-XB-VeV" id="1T6-VA-eJr"/>
                         <outlet property="snoozeButton" destination="QxI-Mz-c2E" id="fvE-ps-o54"/>
                         <outlet property="spriteKitView" destination="dot-Yq-gkc" id="VQK-0m-Y6R"/>
                         <outlet property="statsPanelView" destination="8KP-K7-ZDM" id="TEl-Rt-zAb"/>
                         <outlet property="timeLabel" destination="YvM-WS-hyk" id="t6A-d4-mVH"/>
-                        <outlet property="volumeContainerView" destination="4hs-Gk-Xl6" id="0Wm-7G-jj6"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ktO-hG-udg" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="604" y="-306"/>
+            <point key="canvasLocation" x="602.89855072463774" y="-306.02678571428572"/>
         </scene>
         <!--Nightscout-->
         <scene sceneID="TLg-eV-0T7">

--- a/nightguard/BasicStats.swift
+++ b/nightguard/BasicStats.swift
@@ -1,0 +1,87 @@
+//
+//  BasicStats.swift
+//  nightguard
+//
+//  Created by Florian Preknya on 3/1/19.
+//  Copyright © 2019 private. All rights reserved.
+//
+
+import Foundation
+
+struct BasicStats {
+    
+    let averageGlucose: Float
+    let a1c: Float
+    
+    let readingsCount: Int
+    let readingsMaximumCount: Int = 288 // maximum for 24h
+    var readingsPercentage: Float {
+        return Float(readingsCount) / Float(readingsMaximumCount)
+    }
+    
+    let invalidValuesCount: Int
+    var invalidValuesPercentage: Float {
+        return (readingsCount != 0) ? (Float(invalidValuesCount) / Float(readingsCount)) : 0
+    }
+    
+    let lowValuesCount: Int
+    var lowValuesPercentage: Float {
+        return (readingsCount != 0) ? (Float(lowValuesCount) / Float(readingsCount)) : 0
+    }
+    
+    let highValuesCount: Int
+    var highValuesPercentage: Float {
+        return (readingsCount != 0) ? (Float(highValuesCount) / Float(readingsCount)) : 0
+    }
+    
+    let inRangeValuesCount: Int
+    var inRangeValuesPercentage: Float {
+        return (readingsCount != 0) ? (Float(inRangeValuesCount) / Float(readingsCount)) : 0
+    }
+    
+    init() {
+        
+        // get the readings
+        
+        // get today's data
+        let todaysReadings = NightscoutCacheService.singleton.getTodaysBgData()
+        
+        // get yesterday's data, the ones that are newer than 24h
+        let now = Date()
+        let yesterdaysReadings = NightscoutCacheService.singleton.getYesterdaysBgData()
+        let yesterdaysReadingsNewerThan24h = yesterdaysReadings.suffix(yesterdaysReadings.count) { $0.date > now }
+
+        // 24h values
+        let last24hReadings = yesterdaysReadingsNewerThan24h + todaysReadings
+        
+        // get the upper/lower bounds
+        let upperBound = UserDefaultsRepository.upperBound.value
+        let lowerBound = UserDefaultsRepository.lowerBound.value
+
+        self.readingsCount = last24hReadings.count
+        
+        var invalidValuesCount = 0, lowValuesCount = 0, highValuesCount = 0, inRangeValuesCount = 0
+        for reading in last24hReadings {
+            guard reading.isValid else {
+                invalidValuesCount += 1
+                continue
+            }
+            
+            if reading.value <= lowerBound {
+                lowValuesCount += 1
+            } else if reading.value >= upperBound {
+                highValuesCount += 1
+            } else {
+                inRangeValuesCount += 1
+            }
+        }
+        
+        self.invalidValuesCount = invalidValuesCount
+        self.lowValuesCount = lowValuesCount
+        self.highValuesCount = highValuesCount
+        self.inRangeValuesCount = inRangeValuesCount
+        
+        self.averageGlucose = last24hReadings.reduce(0, { sum, bg in return sum + bg.value }) / Float(last24hReadings.count)
+        self.a1c = (46.7 + self.averageGlucose) / 28.7
+    }
+}

--- a/nightguard/BasicStats.swift
+++ b/nightguard/BasicStats.swift
@@ -143,11 +143,18 @@ struct BasicStats {
         return (validReadingsCount != 0) ? (Float(inRangeValuesCount) / Float(validReadingsCount)).roundTo3f : 0
     }
     
-    var containsMostRecentReading: Bool {
-        return period.readings.last == self.latestReading
+    /// Returns true if the stats are actual, with respect for the input data (contains the most recent readings & the current upper-lower bounds).
+    var isUpToDate: Bool {
+        return
+            self.period.readings.last == self.latestReading &&
+            self.upperBound == UserDefaultsRepository.upperBound.value &&
+            self.lowerBound == UserDefaultsRepository.lowerBound.value
     }
     
+    // store some relevant data about the stats input data (to be able to tell later if the stats are "up to date")
     fileprivate let latestReading: BloodSugar?
+    fileprivate let upperBound: Float
+    fileprivate let lowerBound: Float
     
     init(period: Period = Period.last24h) {
         
@@ -157,8 +164,8 @@ struct BasicStats {
         let readings = period.readings
         
         // get the upper/lower bounds
-        let upperBound = UserDefaultsRepository.upperBound.value
-        let lowerBound = UserDefaultsRepository.lowerBound.value
+        self.upperBound = UserDefaultsRepository.upperBound.value
+        self.lowerBound = UserDefaultsRepository.lowerBound.value
 
         self.readingsCount = readings.count
         self.latestReading = readings.last

--- a/nightguard/BasicStats.swift
+++ b/nightguard/BasicStats.swift
@@ -8,6 +8,9 @@
 
 import Foundation
 
+/**
+ The stats values calculated by considering all the readings for a given (recent) period.
+ */
 struct BasicStats {
     
     // The time period of the stats data (most recent data)

--- a/nightguard/BasicStats.swift
+++ b/nightguard/BasicStats.swift
@@ -143,6 +143,12 @@ struct BasicStats {
         return (validReadingsCount != 0) ? (Float(inRangeValuesCount) / Float(validReadingsCount)).roundTo3f : 0
     }
     
+    var containsMostRecentReading: Bool {
+        return period.readings.last == self.latestReading
+    }
+    
+    fileprivate let latestReading: BloodSugar?
+    
     init(period: Period = Period.last24h) {
         
         self.period = period
@@ -155,6 +161,7 @@ struct BasicStats {
         let lowerBound = UserDefaultsRepository.lowerBound.value
 
         self.readingsCount = readings.count
+        self.latestReading = readings.last
         
         var invalidValuesCount = 0, lowValuesCount = 0, highValuesCount = 0, inRangeValuesCount = 0
         var totalGlucoseCount: Float = 0

--- a/nightguard/BasicStatsControl.swift
+++ b/nightguard/BasicStatsControl.swift
@@ -170,10 +170,6 @@ class BasicStatsControl: TouchReportingView {
     
     func updateTitleView(name: String?, value: String?, detail: String? = nil) {
         
-        guard let titleView = diagramView.titleView else {
-            return
-        }
-        
         nameLabel?.text = name
         updateValueLabel(value)
         

--- a/nightguard/BasicStatsControl.swift
+++ b/nightguard/BasicStatsControl.swift
@@ -8,6 +8,9 @@
 
 import UIKit
 
+/**
+ The stats page contains information about a statistic feature (name-value, other attributes used for drawing)
+ */
 struct StatsPage {
     var name: String
     var value: Any?
@@ -22,6 +25,9 @@ struct StatsPage {
     }
 }
 
+/**
+ The base stats view class, a round view that takes a BasicStats instance as model and displays a segment-like chart on margins (optional & very configurable) and property-value labels in the center (the curent stats page). The stats views can contain multiple pages; pages are turned when the user taps the view.
+ */
 class BasicStatsControl: TouchReportingView {
     
     var model: BasicStats? {

--- a/nightguard/BasicStatsControl.swift
+++ b/nightguard/BasicStatsControl.swift
@@ -1,0 +1,182 @@
+//
+//  BasicStatsControl.swift
+//  nightguard
+//
+//  Created by Florian Preknya on 3/18/19.
+//  Copyright © 2019 private. All rights reserved.
+//
+
+import UIKit
+
+struct StatsPage {
+    let segmentIndex: Int?
+    let name: String?
+    let value: (() -> CGFloat)?
+    let formatter: ((CGFloat) -> String)?
+    let color: UIColor?
+    
+    var formattedValue: String? {
+        guard let value = self.value?() else { return nil}
+        return formatter?(value)
+    }
+}
+
+class BasicStatsControl: UIControl {
+    
+    var model: BasicStats? {
+        didSet {
+            diagramView.reloadData()
+            
+            // reveal!
+            UIView.animate(withDuration: 0.8) { [weak self] in
+                self?.diagramView.alpha = 1
+            }
+            
+            modelWasSet()
+        }
+    }
+    
+    var pages: [StatsPage] {
+        
+        // implement in subclasses
+        return [
+            StatsPage(segmentIndex: 0, name: nil, value: nil, formatter: nil, color: .clear)
+        ]
+    }
+    
+    var currentPageIndex: Int = 0 {
+        didSet {
+            pageChanged()
+            diagramView.reloadData()
+        }
+    }
+    
+    var currentPage: StatsPage {
+        return pages[currentPageIndex]
+    }
+    
+    lazy var diagramView: SMDiagramView = createDiagramView()
+    
+    var valueLabel: UILabel? {
+        return (diagramView.titleView as? UIStackView)?.arrangedSubviews.first as? UILabel
+    }
+    var nameLabel: UILabel? {
+        return (diagramView.titleView as? UIStackView)?.arrangedSubviews.last as? UILabel
+    }
+    
+    lazy var isSmallDevice: Bool = {
+        return [.iPhone4, .iPhone5].contains( DeviceSize())
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    
+    func commonInit() {
+        clipsToBounds = true
+        backgroundColor = UIColor.darkGray.withAlphaComponent(0.3)
+        
+        // add to superview
+        addSubview(diagramView)
+        diagramView.pin(to: self)
+        
+        diagramView.titleView = createTitleView()
+        diagramView.isUserInteractionEnabled = false
+        
+        valueLabel?.numberOfLines = 2
+        valueLabel?.preferredMaxLayoutWidth = isSmallDevice ? 56 : 64
+        
+        // hidden until model is set
+        diagramView.alpha = 0
+        
+        addTarget(self, action: #selector(pressed), for: .touchUpInside)
+    }
+    
+    @IBAction func pressed() {
+        if pages.count > 1 {
+            self.currentPageIndex = (self.currentPageIndex + 1) % pages.count
+        }
+    }
+    
+    func modelWasSet() {
+        
+        // update title
+        updateTitleView(name: currentPage.name, value: currentPage.formattedValue)
+    }
+    
+    func pageChanged() {
+        
+        // update title
+        updateTitleView(name: currentPage.name, value: currentPage.formattedValue)
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        self.layer.cornerRadius =  self.bounds.size.height / 2
+    }
+    
+    func updateTitleView(name: String?, value: String?) {
+        
+        guard let titleView = diagramView.titleView else {
+            return
+        }
+        
+        nameLabel?.text = name
+        valueLabel?.text = value
+        
+        titleView.bounds = CGRect(origin: CGPoint.zero, size: titleView.systemLayoutSizeFitting(UILayoutFittingCompressedSize))
+    }
+    
+    private func createDiagramView() -> SMDiagramView {
+        
+        let diagramView = SMDiagramView()
+        diagramView.backgroundColor = .clear
+        
+        // configure
+        diagramView.minProportion = 0.009
+        diagramView.diagramViewMode = .arc // or .segment
+        diagramView.diagramOffset = .zero
+        diagramView.radiusOfSegments = 30.0
+        //        diagramView.radiusOfViews = 50.0
+        diagramView.arcWidth = 8.0 //Ignoring for SMtargetDiagramViewMode.segment
+        diagramView.colorOfSegments = .clear
+        //        targetDiagramView.viewsOffset = .zero
+        diagramView.separatorWidh = 0.0
+        diagramView.separatorColor = .clear
+        
+        return diagramView
+    }
+    
+    private func createTitleView() -> UIView {
+        
+        let valueLabel = UILabel()
+        valueLabel.text = ""
+        valueLabel.textAlignment = .center
+        valueLabel.textColor = UIColor.white
+        valueLabel.font = UIFont.boldSystemFont(ofSize: isSmallDevice ? 13 : 15)
+        
+        let nameLabel = UILabel()
+        nameLabel.text = ""
+        nameLabel.textAlignment = .center
+        nameLabel.textColor = UIColor.white.withAlphaComponent(0.5)
+        nameLabel.font = UIFont.systemFont(ofSize: 9)
+        
+        let stackView = UIStackView(arrangedSubviews: [valueLabel, nameLabel])
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.spacing = isSmallDevice ? 2 : 4
+        
+        return stackView
+    }
+    
+    func percent(_ value: CGFloat) -> String {
+        return "\(Float(value * 100).cleanValue)%"
+    }
+}

--- a/nightguard/BasicStatsControl.swift
+++ b/nightguard/BasicStatsControl.swift
@@ -21,7 +21,7 @@ struct StatsPage {
     }
 }
 
-class BasicStatsControl: UIControl {
+class BasicStatsControl: TouchReportingView {
     
     var model: BasicStats? {
         didSet {
@@ -78,10 +78,24 @@ class BasicStatsControl: UIControl {
         commonInit()
     }
     
-    func commonInit() {
+    override func commonInit() {
+        super.commonInit()
+        
         clipsToBounds = true
         backgroundColor = UIColor.darkGray.withAlphaComponent(0.3)
         
+        onTouchStarted = { [unowned self] in
+            self.diagramView.titleView?.alpha = 0.5
+        }
+
+        onTouchEnded = { [unowned self] in
+            self.diagramView.titleView?.alpha = 1
+        }
+        
+        onTouchUpInside = { [unowned self] in
+            self.changePage()
+        }
+
         // add to superview
         addSubview(diagramView)
         diagramView.pin(to: self)
@@ -89,16 +103,17 @@ class BasicStatsControl: UIControl {
         diagramView.titleView = createTitleView()
         diagramView.isUserInteractionEnabled = false
         
+        nameLabel?.numberOfLines = 2
+        nameLabel?.preferredMaxLayoutWidth = isSmallDevice ? 56 : 64
         valueLabel?.numberOfLines = 2
         valueLabel?.preferredMaxLayoutWidth = isSmallDevice ? 56 : 64
+
         
         // hidden until model is set
         diagramView.alpha = 0
-        
-        addTarget(self, action: #selector(pressed), for: .touchUpInside)
     }
     
-    @IBAction func pressed() {
+    func changePage() {
         if pages.count > 1 {
             self.currentPageIndex = (self.currentPageIndex + 1) % pages.count
         }

--- a/nightguard/BasicStatsControl.swift
+++ b/nightguard/BasicStatsControl.swift
@@ -71,10 +71,6 @@ class BasicStatsControl: TouchReportingView {
         return (diagramView.titleView as? UIStackView)?.arrangedSubviews.last as? UILabel
     }
     
-    lazy var isSmallDevice: Bool = {
-        return [.iPhone4, .iPhone5].contains( DeviceSize())
-    }()
-    
     fileprivate var alternateValueTimer: Timer?
     
     override init(frame: CGRect) {
@@ -112,6 +108,7 @@ class BasicStatsControl: TouchReportingView {
         diagramView.titleView = createTitleView()
         diagramView.isUserInteractionEnabled = false
         
+        let isSmallDevice = DeviceSize().isSmall
         nameLabel?.numberOfLines = 2
         nameLabel?.preferredMaxLayoutWidth = isSmallDevice ? 56 : 64
         valueLabel?.numberOfLines = 2
@@ -225,7 +222,9 @@ class BasicStatsControl: TouchReportingView {
     }
     
     private func createTitleView() -> UIView {
-        
+
+        let isSmallDevice = DeviceSize().isSmall
+
         let valueLabel = UILabel()
         valueLabel.text = ""
         valueLabel.textAlignment = .center
@@ -251,6 +250,8 @@ class BasicStatsControl: TouchReportingView {
         guard let valueLabel = self.valueLabel else {
             return
         }
+        
+        let isSmallDevice = DeviceSize().isSmall
         
         valueLabel.text = value
         if asDetail {

--- a/nightguard/BasicStatsControl.swift
+++ b/nightguard/BasicStatsControl.swift
@@ -211,7 +211,7 @@ class BasicStatsControl: TouchReportingView {
         nameLabel.text = ""
         nameLabel.textAlignment = .center
         nameLabel.textColor = UIColor.white.withAlphaComponent(0.5)
-        nameLabel.font = UIFont.systemFont(ofSize: 9)
+        nameLabel.font = UIFont.systemFont(ofSize: isSmallDevice ? 8 : 9)
         
         let stackView = UIStackView(arrangedSubviews: [valueLabel, nameLabel])
         stackView.axis = .vertical

--- a/nightguard/BasicStatsPanelView.swift
+++ b/nightguard/BasicStatsPanelView.swift
@@ -1,0 +1,43 @@
+//
+//  BasicStatsPanelView.swift
+//  nightguard
+//
+//  Created by Florian Preknya on 3/10/19.
+//  Copyright © 2019 private. All rights reserved.
+//
+
+import UIKit
+
+class BasicStatsPanelView: XibLoadedView {
+    
+    var model: BasicStats? {
+        didSet {
+            glucoseDistributionView.model = model
+            a1cView.model = model
+            readingsStatsView.model = model
+            periodSelectorView.model = model
+        }
+    }
+        
+    @IBOutlet weak var glucoseDistributionView: GlucoseDistributionView!
+    @IBOutlet weak var a1cView: A1cView!
+    @IBOutlet weak var readingsStatsView: ReadingsStatsView!
+    @IBOutlet weak var periodSelectorView: StatsPeriodSelectorView!
+    
+    override func commonInit() {
+        super.commonInit()
+        
+        periodSelectorView.onPeriodChangeRequest = { period in
+            self.model = BasicStats(period: period)
+        }
+        
+        defer {
+            self.model = BasicStats(period: .last24h)
+        }
+    }
+    
+    func updateModel() {
+        self.model = BasicStats(period: self.model?.period ?? .last24h)
+    }
+}
+

--- a/nightguard/BasicStatsPanelView.swift
+++ b/nightguard/BasicStatsPanelView.swift
@@ -8,6 +8,9 @@
 
 import UIKit
 
+/**
+ The stats panel that contains all the rounded stats views.
+ */
 class BasicStatsPanelView: XibLoadedView {
     
     var model: BasicStats? {

--- a/nightguard/BasicStatsPanelView.swift
+++ b/nightguard/BasicStatsPanelView.swift
@@ -40,7 +40,7 @@ class BasicStatsPanelView: XibLoadedView {
     }
     
     func updateModel() {
-        if let model = self.model, model.containsMostRecentReading {
+        if let model = self.model, model.isUpToDate {
             
             // do nothing, the model contains already the most recent reading
         } else {

--- a/nightguard/BasicStatsPanelView.swift
+++ b/nightguard/BasicStatsPanelView.swift
@@ -40,7 +40,14 @@ class BasicStatsPanelView: XibLoadedView {
     }
     
     func updateModel() {
-        self.model = BasicStats(period: self.model?.period ?? .last24h)
+        if let model = self.model, model.containsMostRecentReading {
+            
+            // do nothing, the model contains already the most recent reading
+        } else {
+            
+            // (re)create the model
+            self.model = BasicStats(period: self.model?.period ?? .last24h)
+        }
     }
 }
 

--- a/nightguard/BasicStatsPanelView.xib
+++ b/nightguard/BasicStatsPanelView.xib
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BasicStatsPanelView" customModule="nightguard" customModuleProvider="target">
+            <connections>
+                <outlet property="a1cView" destination="Kfa-xk-szB" id="HRB-lC-2PG"/>
+                <outlet property="glucoseDistributionView" destination="bPt-Vt-icG" id="wZt-i1-XIR"/>
+                <outlet property="periodSelectorView" destination="oi5-Vn-iQD" id="Bd4-gD-xx6"/>
+                <outlet property="readingsStatsView" destination="aaS-tJ-aP0" id="CZh-b7-XlP"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="80"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="IUU-3t-X7R">
+                    <rect key="frame" x="0.0" y="0.0" width="344" height="80"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Kfa-xk-szB" customClass="A1cView" customModule="nightguard" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="width" secondItem="Kfa-xk-szB" secondAttribute="height" multiplier="1:1" id="GTb-x6-Lxf"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bPt-Vt-icG" customClass="GlucoseDistributionView" customModule="nightguard" customModuleProvider="target">
+                            <rect key="frame" x="88" y="0.0" width="80" height="80"/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="width" secondItem="bPt-Vt-icG" secondAttribute="height" multiplier="1:1" id="T3U-j7-0bQ"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aaS-tJ-aP0" customClass="ReadingsStatsView" customModule="nightguard" customModuleProvider="target">
+                            <rect key="frame" x="176" y="0.0" width="80" height="80"/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="width" secondItem="aaS-tJ-aP0" secondAttribute="height" multiplier="1:1" id="mG5-tG-Mba"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oi5-Vn-iQD" customClass="StatsPeriodSelectorView" customModule="nightguard" customModuleProvider="target">
+                            <rect key="frame" x="264" y="0.0" width="80" height="80"/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="width" secondItem="oi5-Vn-iQD" secondAttribute="height" multiplier="1:1" id="WVw-3f-p17"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <constraints>
+                        <constraint firstItem="oi5-Vn-iQD" firstAttribute="width" secondItem="oi5-Vn-iQD" secondAttribute="height" multiplier="1:1" id="3ha-tY-ww1"/>
+                        <constraint firstAttribute="height" relation="lessThanOrEqual" constant="86" id="9tb-fY-fSW"/>
+                        <constraint firstItem="aaS-tJ-aP0" firstAttribute="width" secondItem="aaS-tJ-aP0" secondAttribute="height" multiplier="1:1" id="Jby-I2-PyV"/>
+                        <constraint firstItem="oi5-Vn-iQD" firstAttribute="width" secondItem="oi5-Vn-iQD" secondAttribute="height" multiplier="1:1" id="Pgu-LU-EIH"/>
+                        <constraint firstItem="oi5-Vn-iQD" firstAttribute="width" secondItem="oi5-Vn-iQD" secondAttribute="height" multiplier="1:1" id="Umg-Qy-kO7"/>
+                        <constraint firstItem="aaS-tJ-aP0" firstAttribute="width" secondItem="aaS-tJ-aP0" secondAttribute="height" multiplier="1:1" id="fWY-ac-Li2"/>
+                        <constraint firstItem="bPt-Vt-icG" firstAttribute="width" secondItem="bPt-Vt-icG" secondAttribute="height" multiplier="1:1" id="pkf-yX-5If"/>
+                    </constraints>
+                </stackView>
+            </subviews>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <constraints>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="IUU-3t-X7R" secondAttribute="trailing" id="7Hm-KO-KuM"/>
+                <constraint firstItem="IUU-3t-X7R" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="HeJ-RL-4HO"/>
+                <constraint firstItem="IUU-3t-X7R" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="SVL-f7-ywd"/>
+                <constraint firstItem="IUU-3t-X7R" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="txD-Gv-NnL"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <point key="canvasLocation" x="88.799999999999997" y="-152.02398800599701"/>
+        </view>
+    </objects>
+</document>

--- a/nightguard/Comparable+Extensions.swift
+++ b/nightguard/Comparable+Extensions.swift
@@ -1,0 +1,15 @@
+//
+//  Comparable+Extensions.swift
+//  nightguard
+//
+//  Created by Florian Preknya on 3/22/19.
+//  Copyright © 2019 private. All rights reserved.
+//
+
+import Foundation
+
+extension Comparable {
+    func clamped(to limits: ClosedRange<Self>) -> Self {
+        return min(max(self, limits.lowerBound), limits.upperBound)
+    }
+}

--- a/nightguard/CustomFormViewController.swift
+++ b/nightguard/CustomFormViewController.swift
@@ -222,3 +222,32 @@ extension SelectorViewController {
         }
     }
 }
+
+extension SliderRow {
+    
+    class func glucoseLevelSlider(initialValue: Float, minimumValue: Float, maximumValue: Float, snapIncrementForMgDl: Float = 10.0) -> SliderRow {
+        
+        return SliderRow() { row in
+            row.value = Float(UnitsConverter.toDisplayUnits("\(initialValue)"))!
+            }.cellSetup { cell, row in
+                
+                let minimumValue = Float(UnitsConverter.toDisplayUnits("\(minimumValue)"))!
+                let maximumValue = Float(UnitsConverter.toDisplayUnits("\(maximumValue)"))!
+                let snapIncrement = (UserDefaultsRepository.units.value == .mgdl) ? snapIncrementForMgDl : 0.1
+                
+                let steps = (maximumValue - minimumValue) / snapIncrement
+                row.steps = UInt(steps.rounded())
+                cell.slider.minimumValue = minimumValue
+                cell.slider.maximumValue = maximumValue
+                row.displayValueFor = { value in
+                    guard let value = value else { return "" }
+                    let units = UserDefaultsRepository.units.value.description
+                    return String("\(value.cleanValue) \(units)")
+                }
+                
+                // fixed width for value label
+                let widthConstraint = NSLayoutConstraint(item: cell.valueLabel, attribute: NSLayoutConstraint.Attribute.width, relatedBy: NSLayoutConstraint.Relation.equal, toItem: nil, attribute: NSLayoutConstraint.Attribute.notAnAttribute, multiplier: 1, constant: 96)
+                cell.valueLabel.addConstraints([widthConstraint])
+        }
+    }
+}

--- a/nightguard/DeviceSize.swift
+++ b/nightguard/DeviceSize.swift
@@ -78,3 +78,9 @@ enum DeviceSize {
         }
     }
 }
+
+extension DeviceSize {
+    var isSmall: Bool {
+        return self == .iPhone4 || self == .iPhone5
+    }
+}

--- a/nightguard/FloatExtension.swift
+++ b/nightguard/FloatExtension.swift
@@ -16,4 +16,13 @@ extension Float {
             ? String(format: "%5.0f", self).trimmingCharacters(in: CharacterSet.whitespaces)
             : String(format: "%5.1f", self).trimmingCharacters(in: CharacterSet.whitespaces)
     }
+    
+    var roundTo3f: Float {
+        return round(to: 3)
+    }
+    
+    func round(to places: Int) -> Float {
+        let divisor = pow(10.0, Float(places))
+        return (divisor * self).rounded() / divisor
+    }
 }

--- a/nightguard/GlucoseDistributionView.swift
+++ b/nightguard/GlucoseDistributionView.swift
@@ -10,18 +10,13 @@ import UIKit
 
 class GlucoseDistributionView: BasicStatsControl {
     
-    override var pages: [StatsPage] {
+    override func createPages() -> [StatsPage] {
+        
         return [
-            StatsPage(segmentIndex: 1, name: "In Range", value: { [weak self] in
-                CGFloat(self?.model?.inRangeValuesPercentage ?? 0)
-                }, formatter: percent, color: .green),
-            StatsPage(segmentIndex: 0, name: "Low", value: { [weak self] in
-                CGFloat(self?.model?.lowValuesPercentage ?? 0)
-                }, formatter: percent, color: .red),
-            StatsPage(segmentIndex: 2, name: "High", value: { [weak self] in
-                CGFloat(self?.model?.highValuesPercentage ?? 0)
-                }, formatter: percent, color: .yellow),
-            StatsPage(segmentIndex: nil, name: nil, value: nil, formatter: nil, color: nil)
+            StatsPage(name: "In Range", value: model?.inRangeValuesPercentage, formattedValue: model?.formattedInRangeValuesPercentage, color: .green),
+            StatsPage(name: "Low", value: model?.lowValuesPercentage, formattedValue: model?.formattedLowValuesPercentage, color: .red),
+            StatsPage(name: "High", value: model?.highValuesPercentage, formattedValue: model?.formattedHighValuesPercentage, color: .yellow),
+            StatsPage(name: "")
         ]
     }
     
@@ -42,11 +37,15 @@ class GlucoseDistributionView: BasicStatsControl {
 extension GlucoseDistributionView: SMDiagramViewDataSource {
     
     @objc func numberOfSegmentsIn(diagramView: SMDiagramView) -> Int {
-        return 3
+        return pages.count - 1
     }
     
     func diagramView(_ diagramView: SMDiagramView, proportionForSegmentAtIndex index: NSInteger) -> CGFloat {
-        return pages[index].value?() ?? 0
+        guard let value = pages[index].value as? Float else {
+            return 0
+        }
+        
+        return CGFloat(value)
     }
     
     func diagramView(_ diagramView: SMDiagramView, colorForSegmentAtIndex index: NSInteger, angle: CGFloat) -> UIColor? {
@@ -67,13 +66,13 @@ extension GlucoseDistributionView: SMDiagramViewDataSource {
         if diagramView.diagramViewMode == .arc {
             return nil
         } else {
-            guard let percentage = pages[index].value?(), percentage > 0.3 else {
+            guard let percentage = pages[index].value as? Float, percentage > 0.3 else {
                 // not big enough!
                 return nil
             }
             
             let percentsLabel = UILabel()
-            percentsLabel.text = percent(percentage)
+            percentsLabel.text = pages[index].formattedValue
             percentsLabel.textColor = UIColor.white.withAlphaComponent(0.7)
             percentsLabel.clipsToBounds = false
             percentsLabel.layer.shadowColor = UIColor.black.cgColor

--- a/nightguard/GlucoseDistributionView.swift
+++ b/nightguard/GlucoseDistributionView.swift
@@ -15,10 +15,20 @@ class GlucoseDistributionView: BasicStatsControl {
     
     override func createPages() -> [StatsPage] {
         
+        var lowDuration: String?
+        if let lowValuesCount = model?.lowValuesCount, lowValuesCount > 0 {
+            lowDuration = formattedDuration(fromReadingsCount: lowValuesCount)
+        }
+        
+        var highDuration: String?
+        if let highValuesCount = model?.highValuesCount, highValuesCount > 0 {
+            highDuration = formattedDuration(fromReadingsCount: highValuesCount)
+        }
+        
         return [
             StatsPage(name: "In Range", value: model?.inRangeValuesPercentage, formattedValue: model?.formattedInRangeValuesPercentage, color: .green),
-            StatsPage(name: "Low", value: model?.lowValuesPercentage, formattedValue: model?.formattedLowValuesPercentage, color: .red),
-            StatsPage(name: "High", value: model?.highValuesPercentage, formattedValue: model?.formattedHighValuesPercentage, color: .yellow),
+            StatsPage(name: "Low", value: model?.lowValuesPercentage, formattedValue: model?.formattedLowValuesPercentage, detail: lowDuration, color: .red),
+            StatsPage(name: "High", value: model?.highValuesPercentage, formattedValue: model?.formattedHighValuesPercentage, detail: highDuration, color: .yellow),
             StatsPage(name: "")
         ]
     }
@@ -107,5 +117,5 @@ extension GlucoseDistributionView: SMDiagramViewDataSource {
     func diagramView(_ diagramView: SMDiagramView, lineWidthForSegmentAtIndex index: NSInteger, angle: CGFloat) -> CGFloat {
         //not called for SMDiagramViewModeSegment
         return (index == currentPageIndex) ? 8.0 : 6.0
-    }
+    }    
 }

--- a/nightguard/GlucoseDistributionView.swift
+++ b/nightguard/GlucoseDistributionView.swift
@@ -1,0 +1,109 @@
+//
+//  GlucoseDistributionView.swift
+//  nightguard
+//
+//  Created by Florian Preknya on 3/18/19.
+//  Copyright © 2019 private. All rights reserved.
+//
+
+import UIKit
+
+class GlucoseDistributionView: BasicStatsControl {
+    
+    override var pages: [StatsPage] {
+        return [
+            StatsPage(segmentIndex: 1, name: "In Range", value: { [weak self] in
+                CGFloat(self?.model?.inRangeValuesPercentage ?? 0)
+                }, formatter: percent, color: .green),
+            StatsPage(segmentIndex: 0, name: "Low", value: { [weak self] in
+                CGFloat(self?.model?.lowValuesPercentage ?? 0)
+                }, formatter: percent, color: .red),
+            StatsPage(segmentIndex: 2, name: "High", value: { [weak self] in
+                CGFloat(self?.model?.highValuesPercentage ?? 0)
+                }, formatter: percent, color: .yellow),
+            StatsPage(segmentIndex: nil, name: nil, value: nil, formatter: nil, color: nil)
+        ]
+    }
+    
+    override func commonInit() {
+        super.commonInit()
+        
+        diagramView.dataSource = self
+    }
+    
+    override func pageChanged() {
+        super.pageChanged()
+        
+        // display segments for last page
+        diagramView.diagramViewMode = (currentPageIndex == (pages.count - 1)) ? .segment : .arc
+    }
+}
+
+extension GlucoseDistributionView: SMDiagramViewDataSource {
+    
+    @objc func numberOfSegmentsIn(diagramView: SMDiagramView) -> Int {
+        return 3
+    }
+    
+    func diagramView(_ diagramView: SMDiagramView, proportionForSegmentAtIndex index: NSInteger) -> CGFloat {
+        return pages[index].value?() ?? 0
+    }
+    
+    func diagramView(_ diagramView: SMDiagramView, colorForSegmentAtIndex index: NSInteger, angle: CGFloat) -> UIColor? {
+        
+        var color = pages[index].color
+        
+        //        if diagramView.diagramViewMode == .arc {
+        if index != currentPageIndex {
+            color = color?.withAlphaComponent(0.7)
+        }
+        //        }
+        
+        return color
+    }
+    
+    func diagramView(_ diagramView: SMDiagramView, viewForSegmentAtIndex index: NSInteger, colorOfSegment color:UIColor?, angle: CGFloat) -> UIView? {
+        
+        if diagramView.diagramViewMode == .arc {
+            return nil
+        } else {
+            guard let percentage = pages[index].value?(), percentage > 0.3 else {
+                // not big enough!
+                return nil
+            }
+            
+            let percentsLabel = UILabel()
+            percentsLabel.text = percent(percentage)
+            percentsLabel.textColor = UIColor.white.withAlphaComponent(0.7)
+            percentsLabel.clipsToBounds = false
+            percentsLabel.layer.shadowColor = UIColor.black.cgColor
+            percentsLabel.layer.shadowOpacity = 1.0
+            percentsLabel.layer.shadowOffset = CGSize(width: 2, height: 2)
+            
+            percentsLabel.font = UIFont.boldSystemFont(ofSize: 9)
+            percentsLabel.sizeToFit()
+            return percentsLabel
+        }
+    }
+    
+    func diagramView(_ diagramView: SMDiagramView, offsetForView view: UIView?, atIndex index: NSInteger, angle: CGFloat) -> CGPoint {
+        return .zero
+    }
+    
+    func diagramView(_ diagramView: SMDiagramView, radiusForView view: UIView?, atIndex index: NSInteger, radiusOfSegment radius: CGFloat, angle: CGFloat) -> CGFloat {
+        return diagramView.frame.size.height / 4
+    }
+    
+    func diagramView(_ diagramView: SMDiagramView, radiusForSegmentAtIndex index: NSInteger, proportion: CGFloat, angle: CGFloat) -> CGFloat {
+        if diagramView.diagramViewMode == .arc {
+            return (diagramView.frame.size.height - diagramView.arcWidth) / 2 + ((index == currentPageIndex) ? 0 : 1)
+        } else {
+            return diagramView.frame.size.height
+        }
+    }
+    
+    func diagramView(_ diagramView: SMDiagramView, lineWidthForSegmentAtIndex index: NSInteger, angle: CGFloat) -> CGFloat {
+        //not called for SMDiagramViewModeSegment
+        return (index == currentPageIndex) ? 8.0 : 6.0
+    }
+}

--- a/nightguard/GlucoseDistributionView.swift
+++ b/nightguard/GlucoseDistributionView.swift
@@ -8,6 +8,9 @@
 
 import UIKit
 
+/**
+ The stats view that displays the BG distribution chart & time spent in each individual ranges.
+ */
 class GlucoseDistributionView: BasicStatsControl {
     
     override func createPages() -> [StatsPage] {

--- a/nightguard/MainViewController.swift
+++ b/nightguard/MainViewController.swift
@@ -137,12 +137,7 @@ class MainViewController: UIViewController {
             }
         }
     }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        self.navigationController?.setNavigationBarHidden(false, animated: animated)
-    }
-    
+        
     override func viewDidAppear(_ animated: Bool) {
         
         // Start immediately so that the current time gets displayed at once

--- a/nightguard/MainViewController.swift
+++ b/nightguard/MainViewController.swift
@@ -29,7 +29,6 @@ class MainViewController: UIViewController {
     @IBOutlet weak var bgStackView: UIStackView!
     
     @IBOutlet weak var nightscoutButton: UIButton!
-    @IBOutlet weak var statsLabel: UILabel!
     @IBOutlet weak var statsPanelView: BasicStatsPanelView!
     
     // the way that has already been moved during a pan gesture
@@ -122,6 +121,21 @@ class MainViewController: UIViewController {
         
         self.navigationController?.setNavigationBarHidden(true, animated: animated)
         showHideRawBGPanel()
+
+        // show/hide the stats panel, using user preference value
+        let statsShouldBeHidden = !UserDefaultsRepository.showStats.value
+        if statsPanelView.isHidden != statsShouldBeHidden {
+            statsPanelView.isHidden = statsShouldBeHidden
+            
+            view.setNeedsLayout()
+            view.layoutIfNeeded()
+            
+            if !statsPanelView.isHidden {
+                DispatchQueue.main.async { [unowned self] in
+                    self.statsPanelView.updateModel()
+                }
+            }
+        }
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -146,6 +160,11 @@ class MainViewController: UIViewController {
         
         // keep the nightscout button round
         nightscoutButton.layer.cornerRadius = nightscoutButton.bounds.size.width / 2
+        
+        DispatchQueue.main.async { [unowned self] in
+            self.chartScene.size = CGSize(width: self.spriteKitView.bounds.width, height: self.spriteKitView.bounds.height)
+            self.loadAndPaintChartData(forceRepaint: true)
+        }
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -450,6 +469,8 @@ class MainViewController: UIViewController {
         
         // update the UI
 //        statsLabel.text = "A1c: \(String(format: "%.1f", basicStats!.a1c))%, in: \(String(format: "%.1f", basicStats!.inRangeValuesPercentage * 100))%"
-        statsPanelView.updateModel()
+        if !statsPanelView.isHidden {
+            statsPanelView.updateModel()
+        }
     }
 }

--- a/nightguard/MainViewController.swift
+++ b/nightguard/MainViewController.swift
@@ -30,6 +30,7 @@ class MainViewController: UIViewController {
     
     @IBOutlet weak var nightscoutButton: UIButton!
     @IBOutlet weak var statsLabel: UILabel!
+    @IBOutlet weak var statsPanelView: BasicStatsPanelView!
     
     // the way that has already been moved during a pan gesture
     var oldXTranslation : CGFloat = 0
@@ -360,7 +361,6 @@ class MainViewController: UIViewController {
             case .data(let newNightscoutData):
                 self.errorPanelView.isHidden = true
                 self.paintCurrentBgData(currentNightscoutData: newNightscoutData)
-                self.updateBasicStats()
                 
                 WatchService.singleton.sendToWatchCurrentNightwatchData()
             }
@@ -404,6 +404,7 @@ class MainViewController: UIViewController {
             if case .data(let newTodaysData) = result {
                 let cachedYesterdaysData = NightscoutCacheService.singleton.getYesterdaysBgData()
                 self.paintChartData(todaysData: newTodaysData, yesterdaysData: cachedYesterdaysData)
+                self.updateBasicStats()
             }
         }
         
@@ -413,6 +414,7 @@ class MainViewController: UIViewController {
             if case .data(let newYesterdaysData) = result {
                 let cachedTodaysBgData = NightscoutCacheService.singleton.getTodaysBgData()
                 self.paintChartData(todaysData: cachedTodaysBgData, yesterdaysData: newYesterdaysData)
+                self.updateBasicStats()
             }
         }
         
@@ -446,10 +448,8 @@ class MainViewController: UIViewController {
     
     fileprivate func updateBasicStats() {
         
-        // recreate the basic stats object
-        self.basicStats = BasicStats()
-        
         // update the UI
-        statsLabel.text = "A1C: \(String(format: "%.1f", basicStats!.a1c))%, in: \(String(format: "%.1f", basicStats!.inRangeValuesPercentage * 100))%"
+//        statsLabel.text = "A1c: \(String(format: "%.1f", basicStats!.a1c))%, in: \(String(format: "%.1f", basicStats!.inRangeValuesPercentage * 100))%"
+        statsPanelView.updateModel()
     }
 }

--- a/nightguard/MainViewController.swift
+++ b/nightguard/MainViewController.swift
@@ -21,7 +21,6 @@ class MainViewController: UIViewController {
     @IBOutlet weak var batteryLabel: UILabel!
     @IBOutlet weak var iobLabel: UILabel!
     @IBOutlet weak var snoozeButton: UIButton!
-    @IBOutlet weak var volumeContainerView: UIView!
     @IBOutlet weak var spriteKitView: UIView!
     @IBOutlet weak var errorPanelView: UIView!
     @IBOutlet weak var errorLabel: UILabel!
@@ -29,6 +28,7 @@ class MainViewController: UIViewController {
     @IBOutlet weak var bgStackView: UIStackView!
     
     @IBOutlet weak var nightscoutButton: UIButton!
+    @IBOutlet weak var nightscoutButtonPanelView: UIView!
     @IBOutlet weak var statsPanelView: BasicStatsPanelView!
     
     // the way that has already been moved during a pan gesture
@@ -50,20 +50,11 @@ class MainViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        // Embed the Volume Slider View
-        // This way the system volume can be
-        // controlled by the user
-        let volumeView = MPVolumeView(frame: volumeContainerView.bounds)
-        volumeView.backgroundColor = UIColor.black
-        volumeView.tintColor = UIColor.gray
-        volumeContainerView.addSubview(volumeView)
-        // add an observer to resize the MPVolumeView when displayed on e.g. 4.7" iPhone
-        volumeContainerView.addObserver(self, forKeyPath: "bounds", options: [], context: nil)
-        volumeContainerView.isHidden = true
-        
         snoozeButton.titleLabel?.numberOfLines = 0
         snoozeButton.titleLabel?.lineBreakMode = .byWordWrapping
         snoozeButton.backgroundColor = UIColor.darkGray.withAlphaComponent(0.3)
+        snoozeButton.titleLabel?.font = UIFont.systemFont(ofSize: DeviceSize().isSmall ? 24 : 27)
+        snoozeButton.titleLabel?.textAlignment = .center
         
         // Initialize the ChartScene
         chartScene = ChartScene(size: CGSize(width: spriteKitView.bounds.width, height: spriteKitView.bounds.height),
@@ -92,6 +83,7 @@ class MainViewController: UIViewController {
         let nightscoutImage = UIImage(named: "Nightscout")?.withRenderingMode(.alwaysTemplate)
         nightscoutButton.setImage(nightscoutImage, for: .normal)
         nightscoutButton.backgroundColor = UIColor.darkGray.withAlphaComponent(0.3)
+        nightscoutButtonPanelView.backgroundColor = .black
         
         // stop timer when app enters in background, start is again when becomes active
         NotificationCenter.default.addObserver(self, selector: #selector(applicationDidEnterBackground(_:)), name: NSNotification.Name.UIApplicationDidEnterBackground, object: nil)
@@ -155,6 +147,7 @@ class MainViewController: UIViewController {
         
         // keep the nightscout button round
         nightscoutButton.layer.cornerRadius = nightscoutButton.bounds.size.width / 2
+        nightscoutButtonPanelView.layer.cornerRadius = nightscoutButtonPanelView.bounds.size.width / 2
         
         DispatchQueue.main.async { [unowned self] in
             self.chartScene.size = CGSize(width: self.spriteKitView.bounds.width, height: self.spriteKitView.bounds.height)
@@ -203,20 +196,6 @@ class MainViewController: UIViewController {
         } else {
             chartScene.scale(recognizer.scale, keepScale: false, infoLabelText: "")
         }
-    }
-    
-    // Resize the MPVolumeView when the parent view changes
-    // This is needed on an e.g. 4,7" iPhone. Otherwise the MPVolumeView would be too small
-    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-
-        let volumeView = MPVolumeView(frame: volumeContainerView.bounds)
-        volumeView.backgroundColor = UIColor.black
-        volumeView.tintColor = UIColor.gray
-
-        for view in volumeContainerView.subviews {
-            view.removeFromSuperview()
-        }
-        volumeContainerView.addSubview(volumeView)
     }
     
     override var preferredStatusBarStyle : UIStatusBarStyle {
@@ -299,6 +278,7 @@ class MainViewController: UIViewController {
         var subtitle = AlarmRule.getAlarmActivationReason(ignoreSnooze: true)
         var subtitleColor: UIColor = (subtitle != nil) ? .red : .white
         var showSubtitle = true
+        let isSmallDevice = DeviceSize().isSmall
         
         if subtitle == nil {
             
@@ -323,12 +303,12 @@ class MainViewController: UIViewController {
             style.lineBreakMode = .byWordWrapping
             
             let titleAttributes: [NSAttributedStringKey : Any] = [
-                NSAttributedString.Key.font: UIFont.systemFont(ofSize: 32),
+                NSAttributedString.Key.font: UIFont.systemFont(ofSize: isSmallDevice ? 24 : 27),
                 NSAttributedString.Key.paragraphStyle: style
             ]
             
             let messageAttributes: [NSAttributedStringKey : Any] = [
-                NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16),
+                NSAttributedString.Key.font: UIFont.systemFont(ofSize: isSmallDevice ? 14 : 16),
                 NSAttributedString.Key.foregroundColor: subtitleColor,
                 NSAttributedString.Key.paragraphStyle: style
             ]
@@ -337,7 +317,6 @@ class MainViewController: UIViewController {
             attString.append(NSAttributedString(string: title, attributes: titleAttributes))
             attString.append(NSAttributedString(string: "\n"))
             attString.append(NSAttributedString(string: subtitle, attributes: messageAttributes))
-            
             snoozeButton.setAttributedTitle(attString, for: .normal)
         } else {
             snoozeButton.setAttributedTitle(nil, for: .normal)

--- a/nightguard/PersistentHighViewController.swift
+++ b/nightguard/PersistentHighViewController.swift
@@ -1,0 +1,76 @@
+//
+//  PersistentHighViewController.swift
+//  nightguard
+//
+//  Created by Florian Preknya on 3/28/19.
+//  Copyright © 2019 private. All rights reserved.
+//
+
+import UIKit
+import Eureka
+
+class PersistentHighViewController: CustomFormViewController {
+    
+    var urgentHighSliderRow: SliderRow!
+    
+    fileprivate let alarmOptions = [15, 20, 30, 45, 60, 90, 120]
+    private var selectableSection: SelectableSection<ListCheckRow<Int>>!
+    
+    override func constructForm() {
+        
+        selectableSection = SelectableSection<ListCheckRow<Int>>("Alert when high BG for more than", selectionType: .singleSelection(enableDeselection: true))
+        selectableSection.onSelectSelectableRow = { cell, row in
+            guard let value = row.value else { return }
+            AlarmRule.persistentHighMinutes.value = value
+        }
+        selectableSection.hidden = "$PersistentHighSwitch == false"
+        
+        for option in alarmOptions {
+            selectableSection <<< ListCheckRow<Int>("\(option) Minutes") { lrow in
+                lrow.title = "\(option) Minutes"
+                lrow.selectableValue = option
+                lrow.value = (option == AlarmRule.persistentHighMinutes.value) ? option : nil
+            }
+        }
+        
+        urgentHighSliderRow = SliderRow.glucoseLevelSlider(initialValue: AlarmRule.persistentHighUpperBound.value, minimumValue: AlarmRule.alertIfAboveValue.value, maximumValue: 300)
+        urgentHighSliderRow.cell.slider.addTarget(self, action: #selector(onSliderValueChanged(slider:event:)), for: .valueChanged)
+        
+        let urgentHighSection = Section(header: "Urgent High", footer: "Alerts anytime when the blood glucose raises above this value.")
+        urgentHighSection <<< urgentHighSliderRow
+        urgentHighSection.hidden = "$PersistentHighSwitch == false"
+
+        
+        form +++ Section(header: "", footer: "Alerts when the BG remains high for a longer period. When on, this alert will delay the high BG alert until the period elapsed or until reaching a maximum BG level (urgent high).")
+            <<< SwitchRow("PersistentHighSwitch") { row in
+                row.title = "Persistent High"
+                row.value = AlarmRule.isPersistentHighEnabled.value
+                }.onChange { row in
+                    guard let value = row.value else { return }
+                    AlarmRule.isPersistentHighEnabled.value = value
+            }
+            
+            +++ selectableSection
+            +++ urgentHighSection
+    }
+    
+    @objc func onSliderValueChanged(slider: UISlider, event: UIEvent) {
+        guard let touchEvent = event.allTouches?.first else { return }
+        
+        // modify UserDefaultsValue ONLY when slider value change events ended
+        switch touchEvent.phase {
+        case .ended:
+            if slider === urgentHighSliderRow.cell.slider {
+                
+                guard let value = urgentHighSliderRow.value else { return }
+                let mgdlValue = UnitsConverter.toMgdl(value)
+                
+                print("Changed (persistent) urgent high slider to \(mgdlValue) \(UserDefaultsRepository.units.value.description)")
+                AlarmRule.persistentHighUpperBound.value = mgdlValue
+            }
+            
+        default:
+            break
+        }
+    }
+}

--- a/nightguard/PrefsViewController.swift
+++ b/nightguard/PrefsViewController.swift
@@ -142,6 +142,14 @@ class PrefsViewController: CustomFormViewController {
             
             +++ Section()
             <<< SwitchRow() { row in
+                row.title = "Show Statistics"
+                row.value = UserDefaultsRepository.showStats.value
+                }.onChange { row in
+                    guard let value = row.value else { return }
+                    UserDefaultsRepository.showStats.value = value
+            }
+
+            <<< SwitchRow() { row in
                 row.title = "Show Raw BG and Noise Level"
                 row.value = UserDefaultsRepository.showRawBG.value
                 }.onChange { [weak self] row in

--- a/nightguard/ReadingsStatsView.swift
+++ b/nightguard/ReadingsStatsView.swift
@@ -23,8 +23,9 @@ class ReadingsStatsView: BasicStatsControl {
         ]
         
         if let invalidValuesCount = model?.invalidValuesCount, invalidValuesCount > 0 {
+            
             pages.append(
-                StatsPage(name: "Invalid readings", value: invalidValuesPercentage, formattedValue: "\(invalidValuesCount)", color: .red)
+                StatsPage(name: "Invalid readings", value: invalidValuesPercentage, formattedValue: "\(invalidValuesCount)", detail: formattedDuration(fromReadingsCount: invalidValuesCount) ,color: .red)
             )
         }
         

--- a/nightguard/ReadingsStatsView.swift
+++ b/nightguard/ReadingsStatsView.swift
@@ -1,0 +1,56 @@
+//
+//  ReadingsStatsView.swift
+//  nightguard
+//
+//  Created by Florian Preknya on 3/18/19.
+//  Copyright © 2019 private. All rights reserved.
+//
+
+import UIKit
+
+class ReadingsStatsView: BasicStatsControl {
+    
+    override var pages: [StatsPage] {
+        return [
+            StatsPage(segmentIndex: -1, name: "Readings", value: { [weak self] in
+                CGFloat(self?.model?.readingsCount ?? 0)
+                }, formatter: { [weak self] value in
+                    "\(Float(value).cleanValue) / \(self?.model?.readingsMaximumCount ?? 0)"
+                }, color: .clear),
+            StatsPage(segmentIndex: 0, name: "Readings %", value: { [weak self] in
+                CGFloat(self?.model?.readingsPercentage ?? 0)
+                }, formatter: percent, color: .white)
+        ]
+    }
+    
+    override func commonInit() {
+        super.commonInit()
+        
+        diagramView.dataSource = self
+    }    
+}
+
+extension ReadingsStatsView: SMDiagramViewDataSource {
+    
+    @objc func numberOfSegmentsIn(diagramView: SMDiagramView) -> Int {
+        return 1
+    }
+    
+    func diagramView(_ diagramView: SMDiagramView, proportionForSegmentAtIndex index: NSInteger) -> CGFloat {
+        return pages[index + 1].value?() ?? 0
+    }
+    
+    func diagramView(_ diagramView: SMDiagramView, colorForSegmentAtIndex index: NSInteger, angle: CGFloat) -> UIColor? {
+        
+        return pages[index + 1].color?.withAlphaComponent(0.5)
+    }
+    
+    func diagramView(_ diagramView: SMDiagramView, radiusForSegmentAtIndex index: NSInteger, proportion: CGFloat, angle: CGFloat) -> CGFloat {
+        return (diagramView.frame.size.height - diagramView.arcWidth) / 2
+    }
+    
+    func diagramView(_ diagramView: SMDiagramView, lineWidthForSegmentAtIndex index: NSInteger, angle: CGFloat) -> CGFloat {
+        //not called for SMDiagramViewModeSegment
+        return 6.0
+    }
+}

--- a/nightguard/ReadingsStatsView.swift
+++ b/nightguard/ReadingsStatsView.swift
@@ -8,6 +8,9 @@
 
 import UIKit
 
+/**
+ The stats view that displays the number of readings in the selected stats period, how many were invalid, etc.
+ */
 class ReadingsStatsView: BasicStatsControl {
     
     override func createPages() -> [StatsPage] {

--- a/nightguard/SMDiagramView.swift
+++ b/nightguard/SMDiagramView.swift
@@ -1,0 +1,440 @@
+//
+//  SMDiagramView.swift
+//  SMDiagramView
+//
+//  Created by OLEKSANDR SEMENIUK on 12/1/17.
+//  Copyright © 2017 OLEKSANDR SEMENIUK. All rights reserved.
+//
+
+import UIKit
+
+@objc public protocol SMDiagramViewDataSource: class {
+    
+    @objc func numberOfSegmentsIn(diagramView: SMDiagramView) -> Int
+    
+    @objc optional func diagramView(_ diagramView: SMDiagramView, proportionForSegmentAtIndex index: NSInteger) -> CGFloat
+    @objc optional func diagramView(_ diagramView: SMDiagramView, colorForSegmentAtIndex index: NSInteger, angle: CGFloat) -> UIColor?
+    @objc optional func diagramView(_ diagramView: SMDiagramView, viewForSegmentAtIndex index: NSInteger, colorOfSegment color:UIColor?, angle: CGFloat) -> UIView?
+    @objc optional func diagramView(_ diagramView: SMDiagramView, offsetForView view: UIView?, atIndex index: NSInteger, angle: CGFloat) -> CGPoint
+    @objc optional func diagramView(_ diagramView: SMDiagramView, radiusForView view: UIView?, atIndex index: NSInteger, radiusOfSegment radius: CGFloat, angle: CGFloat) -> CGFloat
+    @objc optional func diagramView(_ diagramView: SMDiagramView, radiusForSegmentAtIndex index: NSInteger, proportion: CGFloat, angle: CGFloat) -> CGFloat
+    @objc optional func diagramView(_ diagramView: SMDiagramView, lineWidthForSegmentAtIndex index: NSInteger, angle: CGFloat) -> CGFloat //not called for SMDiagramViewModeSegment
+}
+
+@objc public enum SMDiagramViewMode: Int
+{
+    case arc, segment
+}
+
+@objc public class SMDiagramView: UIView
+{
+    private var models = [SMDiagramViewModel]()
+    
+    public var dataSource: SMDiagramViewDataSource?
+    
+    private var _emptyView: UIView?
+    
+    public var emptyView: UIView?
+    {
+        get
+        {
+            return _emptyView
+        }
+        set
+        {
+            _emptyView?.removeFromSuperview()
+            _emptyView = newValue
+            if let view = _emptyView
+            {
+                addSubview(view)
+            }
+            layoutIfNeeded()
+        }
+    }
+    
+    private var _titleView: UIView?
+    
+    public var titleView: UIView?
+    {
+        get
+        {
+            return _titleView
+        }
+        set
+        {
+            _titleView?.removeFromSuperview()
+            _titleView = newValue
+            if let view = _titleView
+            {
+                addSubview(view)
+            }
+            layoutIfNeeded()
+        }
+    }
+    
+    public var minProportion: CGFloat = 0.1
+    public var diagramViewMode: SMDiagramViewMode = .arc
+    public var diagramOffset: CGPoint = .zero
+    public var radiusOfSegments: CGFloat = 80.0
+    public var radiusOfViews: CGFloat = 130.0
+    public var arcWidth: CGFloat = 6.0 //Ignoring for SMDiagramViewMode.segment
+    public var startAngle: CGFloat = -.pi/2
+    public var endAngle: CGFloat = 2.0 * .pi - .pi/2.0
+    public var colorOfSegments: UIColor = .black
+    public var viewsOffset: CGPoint = .zero
+    public var separatorWidh: CGFloat = 1.0
+    private var _separatorColor: UIColor
+    {
+        get
+        {
+            if let color = separatorColor
+            {
+                return color
+            }
+            if let color = backgroundColor
+            {
+                return color
+            }
+            return UIColor.white
+        }
+    }
+    public var separatorColor: UIColor?
+    
+    private var centerOfCircle: CGPoint
+    {
+        get
+        {
+            return CGPoint(x: frame.size.width/2.0 + diagramOffset.x, y: frame.size.height/2.0 + diagramOffset.y)
+        }
+    }
+    
+    override public func draw(_ rect: CGRect)
+    {
+        super.draw(rect)
+        
+        drawDiagram()
+    }
+    
+    override public func layoutSubviews()
+    {
+        super.layoutSubviews()
+        
+        updateViewsPositions()
+    }
+    
+    private func drawDiagram()
+    {
+        for model in models
+        {
+            if let c = UIGraphicsGetCurrentContext()
+            {
+                c.addArc(center: centerOfCircle, radius: model.radiusOfSegment, startAngle: model.startAngle, endAngle: model.endAngle, clockwise: false)
+                c.setLineWidth(model.lineWidth)
+                if let color = model.color
+                {
+                    c.setStrokeColor(color.cgColor)
+                }
+                c.drawPath(using: .stroke)
+            }
+        }
+        
+        if diagramViewMode == .arc
+        {
+            drawSeparator()
+        }
+    }
+    
+    private func drawSeparator()
+    {
+        if models.count < 2
+        {
+            return
+        }
+        
+        for model in models
+        {
+            if let c = UIGraphicsGetCurrentContext()
+            {
+                c.addArc(center: centerOfCircle, radius: model.radiusOfSegment, startAngle: model.separatorStartAngle, endAngle: model.separatorEndAngle, clockwise: false)
+                c.setLineWidth(model.separatorLineWidth)
+                c.setStrokeColor(_separatorColor.cgColor)
+                c.drawPath(using: .stroke)
+            }
+        }
+    }
+    
+    private func removeViews()
+    {
+        for model in models
+        {
+            if let view = model.view
+            {
+                view.removeFromSuperview()
+            }
+        }
+        
+        hideEmptyView()
+    }
+    
+    private func updateViewsPositions()
+    {
+        for model in models
+        {
+            if let view = model.view
+            {
+                view.center = CGPoint(x: centerOfCircle.x + model.viewPosition.x, y: centerOfCircle.y + model.viewPosition.y)
+            }
+        }
+        
+        titleView?.center = centerOfCircle
+    }
+    
+    private func showEmptyView()
+    {
+        if let view = emptyView
+        {
+            bringSubview(toFront: view)
+            view.alpha = 1.0
+            view.isHidden = false
+        }
+    }
+    
+    private func hideEmptyView()
+    {
+        if let view = emptyView
+        {
+            view.alpha = 0.0
+            view.isHidden = true
+        }
+    }
+    
+    private func updateProportions()
+    {
+        var additionalSum: CGFloat = 0.0
+        var lessSum: CGFloat = 0.0
+        var sum: CGFloat = 0.0
+        
+        for model in models
+        {
+            sum += model.calculatedProportion
+            
+            if model.calculatedProportion < minProportion
+            {
+                lessSum += model.calculatedProportion
+                additionalSum += minProportion - model.calculatedProportion
+                model.calculatedProportion = minProportion
+            }
+        }
+        
+        if additionalSum == 0.0
+        {
+            return
+        }
+        
+        let greatSum = sum - lessSum
+        
+        for model in models
+        {
+            if model.calculatedProportion > minProportion
+            {
+                model.calculatedProportion -= (model.calculatedProportion / greatSum) * additionalSum
+            }
+        }
+        
+        updateProportions()
+    }
+    
+    public func reloadData()
+    {
+        removeViews()
+        
+        models.removeAll()
+        
+        let count = dataSource?.numberOfSegmentsIn(diagramView: self)
+        
+        if endAngle > startAngle
+        {
+            if let count = count, count > 0
+            {
+                let originalProportion: CGFloat = 1.0/CGFloat(count)
+                
+                assert(CGFloat(roundf(Float(originalProportion*100))/100) >= minProportion, "SMDiagramView. 1/count should not be less minProportion\ncount = \(count)\nminProportion = \(minProportion)")
+
+                var result = [SMDiagramViewModel]()
+                var totalProportion: CGFloat = 0.0
+                
+                for i in 0 ..< count {
+                    let model = SMDiagramViewModel()
+                    model.originalProportion = dataSource?.diagramView?(self, proportionForSegmentAtIndex: i) ?? originalProportion
+                    
+                    totalProportion += model.originalProportion
+                    
+                    assert(roundf(Float(totalProportion*100))/100 <= 1.0 && totalProportion >= 0.0, "SMDiagramView. Sum of proportions = \(totalProportion) must be less or equal 1.0 or equal 0.0")
+                    
+                    model.calculatedProportion = model.originalProportion
+                    
+                    result.append(model)
+                }
+                
+                models = result
+                
+                updateProportions()
+                var tempStartAngle = startAngle
+                
+                for i in 0 ..< count
+                {
+                    let model = models[i]
+                    
+                    model.startAngle = tempStartAngle
+                    model.angleStep = (endAngle - startAngle)*model.calculatedProportion
+                    
+                    model.color = dataSource?.diagramView?(self, colorForSegmentAtIndex: i, angle: model.angle) ?? colorOfSegments
+                    if let view = dataSource?.diagramView?(self, viewForSegmentAtIndex: i, colorOfSegment: model.color, angle: model.angle)
+                    {
+                        self.addSubview(view)
+                        model.view = view
+                    }
+                    model.radiusOfSegment = dataSource?.diagramView?(self, radiusForSegmentAtIndex: i, proportion: model.calculatedProportion, angle: model.angle) ?? radiusOfSegments
+                    model.radiusOfView = dataSource?.diagramView?(self, radiusForView: model.view, atIndex: i, radiusOfSegment: model.radiusOfSegment, angle: model.angle) ?? radiusOfViews
+                    model.viewOffset = dataSource?.diagramView?(self, offsetForView: model.view, atIndex: i, angle: model.angle) ?? viewsOffset
+                    model.lineWidth = dataSource?.diagramView?(self, lineWidthForSegmentAtIndex: i, angle: model.angle) ?? arcWidth
+                    
+                    model.separatorWidh = separatorWidh
+                    model.diagramViewMode = diagramViewMode
+                    tempStartAngle = model.endAngle
+                }
+            } else
+            {
+                showEmptyView()
+            }
+        }
+        
+        layoutIfNeeded()
+        setNeedsDisplay()
+    }
+    
+}
+
+fileprivate class SMDiagramViewModel
+{
+    var view: UIView?
+    var color: UIColor?
+    var angleStep: CGFloat = 0.0
+    var calculatedProportion: CGFloat = 0.0
+    var originalProportion: CGFloat = 0.0
+    var startAngle: CGFloat = 0.0
+    private var _radiusOfSegment: CGFloat = 0.0
+    private var _lineWidth: CGFloat = 0.0
+    var radiusOfView: CGFloat = 0.0
+    var viewOffset: CGPoint = .zero
+    var separatorWidh: CGFloat = 0.0
+    var diagramViewMode: SMDiagramViewMode = .arc
+    
+    var radiusOfSegment: CGFloat
+    {
+        set
+        {
+            _radiusOfSegment = newValue
+        }
+        
+        get
+        {
+            switch diagramViewMode {
+            case .arc:
+                return _radiusOfSegment
+            case .segment:
+                return _radiusOfSegment/2.0
+            }
+        }
+    }
+    
+    var lineWidth: CGFloat
+    {
+        set
+        {
+            _lineWidth = newValue
+        }
+        
+        get
+        {
+            switch diagramViewMode {
+            case .arc:
+                return _lineWidth
+            case .segment:
+                return _radiusOfSegment
+            }
+        }
+    }
+    
+    var endAngle: CGFloat
+    {
+        get
+        {
+            return startAngle + angleStep
+        }
+    }
+    
+    var angle: CGFloat
+    {
+        get
+        {
+            return endAngle - angleStep/2.0
+        }
+    }
+    
+    var viewPosition: CGPoint
+    {
+        get
+        {
+            return CGPoint(x: xPosition, y: yPosition)
+        }
+    }
+    
+    private var xPosition: CGFloat
+    {
+        get
+        {
+            return CGFloat(cosf(Float(endAngle - angleStep/2.0))) * radiusOfView + viewOffset.x
+        }
+    }
+    
+    private var yPosition: CGFloat
+    {
+        get
+        {
+            return CGFloat(sinf(Float(endAngle - angleStep/2.0))) * radiusOfView + viewOffset.y
+        }
+    }
+    
+    var separatorStartAngle: CGFloat
+    {
+        get
+        {
+            return endAngle - separatorAngleStep/2.0
+        }
+    }
+    
+    var separatorEndAngle: CGFloat
+    {
+        get
+        {
+            return endAngle + separatorAngleStep/2.0
+        }
+    }
+    
+    var separatorAngleStep: CGFloat
+    {
+        get
+        {
+            return separatorWidh/radiusOfSegment
+        }
+    }
+    
+    var separatorLineWidth: CGFloat
+    {
+        get
+        {
+            return lineWidth + 2.0 / UIScreen.main.scale
+        }
+    }
+}

--- a/nightguard/StatsPeriodSelectorView.swift
+++ b/nightguard/StatsPeriodSelectorView.swift
@@ -27,7 +27,7 @@ class StatsPeriodSelectorView: BasicStatsControl {
         super.commonInit()
         
         diagramView.dataSource = self
-        valueLabel?.font = UIFont.boldSystemFont(ofSize: isSmallDevice ? 11 : 13)
+        valueLabel?.font = UIFont.boldSystemFont(ofSize: DeviceSize().isSmall ? 11 : 13)
     }
     
     override func modelWasSet() {
@@ -46,7 +46,7 @@ class StatsPeriodSelectorView: BasicStatsControl {
         super.updateValueLabel(value, asDetail: asDetail)
         
         // override value label font
-        valueLabel?.font = UIFont.boldSystemFont(ofSize: isSmallDevice ? 11 : 13)
+        valueLabel?.font = UIFont.boldSystemFont(ofSize: DeviceSize().isSmall ? 11 : 13)
     }
 }
 

--- a/nightguard/StatsPeriodSelectorView.swift
+++ b/nightguard/StatsPeriodSelectorView.swift
@@ -41,6 +41,13 @@ class StatsPeriodSelectorView: BasicStatsControl {
         let nextPeriodIndex = ((periods.firstIndex(of: period) ?? -1) + 1) % periods.count
         onPeriodChangeRequest?(periods[nextPeriodIndex])
     }
+    
+    override func updateValueLabel(_ value: String?, asDetail: Bool = false) {
+        super.updateValueLabel(value, asDetail: asDetail)
+        
+        // override value label font
+        valueLabel?.font = UIFont.boldSystemFont(ofSize: isSmallDevice ? 11 : 13)
+    }
 }
 
 extension StatsPeriodSelectorView: SMDiagramViewDataSource {

--- a/nightguard/StatsPeriodSelectorView.swift
+++ b/nightguard/StatsPeriodSelectorView.swift
@@ -1,0 +1,62 @@
+//
+//  StatsPeriodSelectorView.swift
+//  nightguard
+//
+//  Created by Florian Preknya on 3/18/19.
+//  Copyright © 2019 private. All rights reserved.
+//
+
+import UIKit
+
+class StatsPeriodSelectorView: BasicStatsControl {
+    
+    var onPeriodChangeRequest: ((BasicStats.Period) -> Void)?
+    
+    fileprivate var periods: [BasicStats.Period] = [
+        .last24h,
+        .last8h,
+        .today,
+        .yesterday,
+        .todayAndYesterday
+    ]
+    
+    override func commonInit() {
+        super.commonInit()
+        
+        diagramView.dataSource = self
+        valueLabel?.font = UIFont.boldSystemFont(ofSize: isSmallDevice ? 11 : 13)
+    }
+    
+    override func modelWasSet() {
+        super.modelWasSet()
+        
+        updateTitleView(name: "Stats Period", value: model?.period.description)
+    }
+    
+    override func pressed() {
+        guard let period = self.model?.period else { return }
+        let nextPeriodIndex = ((periods.firstIndex(of: period) ?? -1) + 1) % periods.count
+        onPeriodChangeRequest?(periods[nextPeriodIndex])
+    }
+}
+
+extension StatsPeriodSelectorView: SMDiagramViewDataSource {
+    
+    @objc func numberOfSegmentsIn(diagramView: SMDiagramView) -> Int {
+        return 1
+    }
+    
+    //    func diagramView(_ diagramView: SMDiagramView, colorForSegmentAtIndex index: NSInteger, angle: CGFloat) -> UIColor? {
+    //
+    //        return UIColor.white.withAlphaComponent(0.025)
+    //    }
+    
+    func diagramView(_ diagramView: SMDiagramView, radiusForSegmentAtIndex index: NSInteger, proportion: CGFloat, angle: CGFloat) -> CGFloat {
+        return (diagramView.frame.size.height - 2/*diagramView.arcWidth*/) / 2
+    }
+    
+    func diagramView(_ diagramView: SMDiagramView, lineWidthForSegmentAtIndex index: NSInteger, angle: CGFloat) -> CGFloat {
+        //not called for SMDiagramViewModeSegment
+        return 2.0
+    }
+}

--- a/nightguard/StatsPeriodSelectorView.swift
+++ b/nightguard/StatsPeriodSelectorView.swift
@@ -33,7 +33,7 @@ class StatsPeriodSelectorView: BasicStatsControl {
         updateTitleView(name: "Stats Period", value: model?.period.description)
     }
     
-    override func pressed() {
+    override func changePage() {
         guard let period = self.model?.period else { return }
         let nextPeriodIndex = ((periods.firstIndex(of: period) ?? -1) + 1) % periods.count
         onPeriodChangeRequest?(periods[nextPeriodIndex])

--- a/nightguard/StatsPeriodSelectorView.swift
+++ b/nightguard/StatsPeriodSelectorView.swift
@@ -8,6 +8,9 @@
 
 import UIKit
 
+/**
+ This is a fake stats view, it is actualy a stats period changer; it was convenable to keep it as a stats view because of the unitar UI.
+ */
 class StatsPeriodSelectorView: BasicStatsControl {
     
     var onPeriodChangeRequest: ((BasicStats.Period) -> Void)?

--- a/nightguard/TouchReportingView.swift
+++ b/nightguard/TouchReportingView.swift
@@ -1,0 +1,62 @@
+//
+//  TouchReportingView.swift
+//  nightguard
+//
+//  Created by Florian Preknya on 3/21/19.
+//  Copyright © 2019 private. All rights reserved.
+//
+
+import UIKit
+
+/// UIButton or UITableViewCell like touch & tap detection UIControl, useful for giving a button behavior to any view (highlighting on touch, execute action on tap).
+class TouchReportingView: UIControl {
+    
+    /// closure called when touch started (isHighlighted == true)
+    var onTouchStarted: (() -> Void)?
+    
+    /// closure called when touch ended (isHighlighted == false)
+    var onTouchEnded: (() -> Void)?
+    
+    /// closure called when a tap is detected
+    var onTouchUpInside: (() -> Void)?
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    
+    func commonInit() {
+        addTarget(self, action: #selector(touchedUp), for: .touchUpInside)
+        addTarget(self, action: #selector(touchedDown), for: .touchDown)
+        addTarget(self, action:  #selector(exited), for: .touchCancel)
+        addTarget(self, action:  #selector(exited), for: .touchDragExit)
+        addTarget(self, action:  #selector(entered), for: .touchDragEnter)
+    }
+    
+    @objc func touchedDown() {
+        onTouchStarted?()
+    }
+    
+    @objc func entered() {
+        onTouchStarted?()
+    }
+    
+    @objc func exited() {
+        UIView.animate(withDuration: 0.4, animations: { [weak self] in
+            self?.onTouchEnded?()
+        })
+    }
+    
+    @objc func touchedUp() {
+        UIView.animate(withDuration: 0.4, animations: { [weak self] in
+            self?.onTouchEnded?()
+        })
+        
+        onTouchUpInside?()
+    }
+}

--- a/nightguard/UIView+Extensions.swift
+++ b/nightguard/UIView+Extensions.swift
@@ -10,6 +10,7 @@ import UIKit
 
 extension UIView {
     func pin(to view: UIView) {
+        translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             leadingAnchor.constraint(equalTo: view.leadingAnchor),
             trailingAnchor.constraint(equalTo: view.trailingAnchor),

--- a/nightguard/XibLoadedView.swift
+++ b/nightguard/XibLoadedView.swift
@@ -1,0 +1,62 @@
+//
+//  XibLoadedView.swift
+//  nightguard
+//
+//  Created by Florian Preknya on 3/12/19.
+//  Copyright © 2019 private. All rights reserved.
+//
+
+import UIKit
+
+class XibLoadedView: UIView {
+    
+    // the custom view from the XIB file
+    var view: UIView!
+    
+    // the XIB file name (by default, the class name - override this property in subclasses if needed)
+    var nibName: String {
+        return NSStringFromClass(type(of: self)).components(separatedBy: ".").last!
+    }
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    
+    func commonInit() {
+        xibSetup()
+    }
+    
+    fileprivate func xibSetup() {
+        self.backgroundColor = .clear
+        view = loadViewFromNib()
+        
+        addSubview(view)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            view.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            view.topAnchor.constraint(equalTo: self.topAnchor),
+            view.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        ])
+    }
+    
+    fileprivate func loadViewFromNib() -> UIView {
+        let bundle = Bundle(for: type(of: self))
+        let nibName = self.nibName
+        guard let _ = bundle.path(forResource: nibName, ofType: "nib") else {
+            return UIView()
+        }
+        
+        let nib = UINib(nibName: nibName, bundle: bundle)
+            
+        // Assumes UIView is top level and only object in CustomView.xib file
+        let view = nib.instantiate(withOwner: self, options: nil)[0] as! UIView
+        return view
+    }
+}


### PR DESCRIPTION
Display some statistics for the most recent readings.
The stats panel contains 3 circular views + a period selector view, each of them having a number of "pages"; tapping the circular view will "turn the page", presenting another stats aspect.
The views:
* glucose average & A1c estimation + glucose variation (standard deviation & coefficient of variation); along the values, a color-meter border gives feedback about the values (green - great, yellow & values in between - ok, red - not so good)
* glucose distribution view: percents/time for having the glucose readings in low/in/high ranges
* readings count, invalid readings view
* period selector - toggles the period between Last 24h / Last 8h / Today / Yesterday / Today & Yesterday.

For the moment, the Low & High thresholds are the Low & High alarm values.

<img width="426" alt="Screen Shot 2019-03-28 at 11 52 26 AM" src="https://user-images.githubusercontent.com/16608127/55150238-667bc180-5154-11e9-8ee9-7b846cac792a.png">
<img width="426" alt="Screen Shot 2019-03-28 at 12 02 59 PM" src="https://user-images.githubusercontent.com/16608127/55150239-667bc180-5154-11e9-92e3-0f713ef4bc35.png">
