### PR TITLE
Sync missed readings alert with watch & persistent snooze timestamp

### DIFF
--- a/nightguard/AlarmRule.swift
+++ b/nightguard/AlarmRule.swift
@@ -46,6 +46,9 @@ class AlarmRule {
     static let alertIfBelowValue = UserDefaultsRepository.lowerBound
     
     static let noDataAlarmEnabled = UserDefaultsValue<Bool>(key: "noDataAlarmEnabled", default: true)
+        .group(UserDefaultsValueGroups.GroupNames.watchSync)
+        .group(UserDefaultsValueGroups.GroupNames.alarm)
+    
     static let minutesWithoutValues = UserDefaultsValue<Int>(key: "noDataAlarmAfterMinutes", default: 15)
         .group(UserDefaultsValueGroups.GroupNames.watchSync)
         .group(UserDefaultsValueGroups.GroupNames.alarm)

--- a/nightguard/AppDelegate.swift
+++ b/nightguard/AppDelegate.swift
@@ -137,10 +137,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             // same comparison for snoozing timestamp
             if let anyWatchSnoozeTimestamp = message.dictionary["snoozedUntilTimestamp"] {
                 let watchSnoozeTimestamp = anyWatchSnoozeTimestamp as? TimeInterval
-                if AlarmRule.snoozedUntilTimestamp != watchSnoozeTimestamp {
+                if AlarmRule.snoozedUntilTimestamp.value != watchSnoozeTimestamp {
                     
                     // send snooze data to watch!
-                    SnoozeMessage(timestamp: AlarmRule.snoozedUntilTimestamp).send()
+                    SnoozeMessage(timestamp: AlarmRule.snoozedUntilTimestamp.value).send()
                     
                     print("Handling WatchSyncRequestMessage: Snooze timestamp on watch didn't match phone snooze timestamp")
                 }


### PR DESCRIPTION
Fixes #70.
The snooze timestamp is now persistent, restarting the app will continue snoozing for the remaining snooze time. 