### PR TITLE
Display the IFCC A1c units also (mmol/mol) in daily stats

### DIFF
--- a/nightguard/A1cView.swift
+++ b/nightguard/A1cView.swift
@@ -30,6 +30,7 @@ class A1cView: BasicStatsControl {
     override func createPages() -> [StatsPage] {
         return [
             StatsPage(name: "A1c", formattedValue: model?.formattedA1c),
+            StatsPage(name: "IFCC A1c", formattedValue: model?.formattedIFCCA1c?.replacingOccurrences(of: " ", with: "\n")),
             StatsPage(name: "Average", formattedValue: model?.formattedAverageGlucose?.replacingOccurrences(of: " ", with: "\n")),
             StatsPage(name: "Std Deviation", formattedValue: model?.formattedStandardDeviation?.replacingOccurrences(of: " ", with: "\n")),
             StatsPage(name: "Coefficient of Variation", formattedValue: model?.formattedCoefficientOfVariation)
@@ -55,7 +56,7 @@ class A1cView: BasicStatsControl {
     }
     
     fileprivate var modelColor: UIColor? {
-        return (currentPageIndex < 2) ? a1cColor : variationColor
+        return (currentPageIndex < 3) ? a1cColor : variationColor
     }
     
     override func commonInit() {
@@ -66,6 +67,11 @@ class A1cView: BasicStatsControl {
 //        diagramView.separatorColor = .black
 //        diagramView.startAngle = .pi * 0.75
 //        diagramView.endAngle = 2 * .pi + .pi * 0.75
+        
+        // cheating: extend the value label width (the mmol/mol units are too long)
+        if let valueLabel = valueLabel {
+            valueLabel.preferredMaxLayoutWidth += 8
+        }
     }
     
     override func modelWasSet() {

--- a/nightguard/BasicStats.swift
+++ b/nightguard/BasicStats.swift
@@ -102,7 +102,13 @@ struct BasicStats {
     let period: Period
     
     let averageGlucose: Float
+    
+    // http://www.ngsp.org/ifccngsp.asp
+    // DCCT (Diabetes Control and Complications Trial) units - percentage
     let a1c: Float
+    // IFCC (International Federation of Clinical Chemistry) units - mmol/mol
+    let ifccA1c: Float
+    
     let standardDeviation: Float
     let coefficientOfVariation: Float
     
@@ -200,6 +206,7 @@ struct BasicStats {
         
         self.averageGlucose = totalGlucoseCount / Float(readings.count - invalidValuesCount)
         self.a1c = (46.7 + self.averageGlucose) / 28.7
+        self.ifccA1c = (self.a1c - 2.152) / 0.09148
         self.standardDeviation = Float(validReadings.map { Double($0.value) }.standardDeviation)
         self.coefficientOfVariation = (self.averageGlucose != 0) ? (self.standardDeviation / self.averageGlucose).roundTo3f : Float.nan
     }
@@ -225,6 +232,10 @@ extension BasicStats {
     
     var formattedA1c: String? {
         return a1c.isNaN ? nil : "\(a1c.round(to: 1).cleanValue)%"
+    }
+    
+    var formattedIFCCA1c: String? {
+        return ifccA1c.isNaN ? nil : "\(ifccA1c.rounded().cleanValue) mmol/mol"
     }
     
     var formattedStandardDeviation: String? {

--- a/nightguard/WatchSyncRequestMessage.swift
+++ b/nightguard/WatchSyncRequestMessage.swift
@@ -20,7 +20,7 @@ class WatchSyncRequestMessage: WatchMessage {
     init() {
         var dictionary = [String: Any]()
         dictionary[UserDefaultsRepository.lastWatchSyncUpdateId.key] = UserDefaultsRepository.lastWatchSyncUpdateId.anyValue
-        dictionary["snoozedUntilTimestamp"] = AlarmRule.snoozedUntilTimestamp
+        dictionary["snoozedUntilTimestamp"] = AlarmRule.snoozedUntilTimestamp.value
         
         self.dictionary = dictionary
     }


### PR DESCRIPTION
Requested by some "CGM in the Cloud" members, as some countries use the mmol/mol units for expressing the A1c value, not percentage. 
