### PR TITLE
QR code scanning and push notification implementation

### DIFF
--- a/nightguard/AppDelegate.swift
+++ b/nightguard/AppDelegate.swift
@@ -69,9 +69,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
             let token = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
             Logger.log("Push registration success: \(token)")
+            DispatchQueue.global(qos: .background).async {
+                let environment = DeviceRegistrationService.shared.apnsEnvironment()
+                DeviceRegistrationService.shared.updateDeviceToken(token, environment: environment)
+            }
             
-            let environment = DeviceRegistrationService.shared.apnsEnvironment()
-            DeviceRegistrationService.shared.updateDeviceToken(token, environment: environment)
         }
     
     func application(

--- a/nightguard/Info.plist
+++ b/nightguard/Info.plist
@@ -34,8 +34,6 @@
 	<string>12.0.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSSupportsLiveActivities</key>
-	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
@@ -45,6 +43,8 @@
 	<string>Synchronize your glucose data from nightscout to apple health. This was a user requested feature. Users wanted to be able to analyze glucose data with other third party apps.</string>
 	<key>NSHealthUpdateUsageDescription</key>
 	<string>Synchronize your glucose data from nightscout to apple health. This was a user requested feature. Users wanted to be able to analyze glucose data with other third party apps.</string>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>ConfigurationIntent</string>
@@ -53,6 +53,7 @@
 	<array>
 		<string>fetch</string>
 		<string>processing</string>
+		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
@@ -69,6 +70,8 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>This app needs camera access to scan QR codes.</string>
 	<key>Wk</key>
 	<string></string>
 </dict>

--- a/nightguard/app/QRScannerViewController.swift
+++ b/nightguard/app/QRScannerViewController.swift
@@ -1,0 +1,103 @@
+//
+//  QRScannerViewController.swift
+//  nightguard
+//
+//  Created by JamOrHam on 27/02/2026.
+//
+
+import Foundation
+import UIKit
+import AVFoundation
+import AudioToolbox
+
+protocol QRScannerDelegate: AnyObject {
+    func didScanQRCode(_ code: String)
+    func didFailScanning(error: Error)
+}
+
+final class QRScannerViewController: UIViewController {
+
+    weak var delegate: QRScannerDelegate?
+
+    private var captureSession: AVCaptureSession?
+    private var previewLayer: AVCaptureVideoPreviewLayer?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+        checkCameraPermission()
+    }
+
+    private func checkCameraPermission() {
+        switch AVCaptureDevice.authorizationStatus(for: .video) {
+        case .authorized:
+            setupScanner()
+        case .notDetermined:
+            AVCaptureDevice.requestAccess(for: .video) { granted in
+                DispatchQueue.main.async {
+                    granted ? self.setupScanner() : self.dismiss(animated: true)
+                }
+            }
+        default:
+            dismiss(animated: true)
+        }
+    }
+
+    private func setupScanner() {
+        let session = AVCaptureSession()
+        guard let videoDevice = AVCaptureDevice.default(for: .video) else { return }
+
+        do {
+            let input = try AVCaptureDeviceInput(device: videoDevice)
+
+            if session.canAddInput(input) {
+                session.addInput(input)
+            }
+
+            let metadataOutput = AVCaptureMetadataOutput()
+
+            if session.canAddOutput(metadataOutput) {
+                session.addOutput(metadataOutput)
+                metadataOutput.setMetadataObjectsDelegate(self, queue: .main)
+                metadataOutput.metadataObjectTypes = [.qr]
+            }
+
+            previewLayer = AVCaptureVideoPreviewLayer(session: session)
+            previewLayer?.frame = view.layer.bounds
+            previewLayer?.videoGravity = .resizeAspectFill
+
+            if let previewLayer = previewLayer {
+                view.layer.addSublayer(previewLayer)
+            }
+
+            captureSession = session
+            session.startRunning()
+
+        } catch {
+            delegate?.didFailScanning(error: error)
+        }
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        captureSession?.stopRunning()
+    }
+}
+
+extension QRScannerViewController: AVCaptureMetadataOutputObjectsDelegate {
+
+    func metadataOutput(_ output: AVCaptureMetadataOutput,
+                        didOutput metadataObjects: [AVMetadataObject],
+                        from connection: AVCaptureConnection) {
+
+        captureSession?.stopRunning()
+
+        guard
+            let metadataObject = metadataObjects.first as? AVMetadataMachineReadableCodeObject,
+            let stringValue = metadataObject.stringValue
+        else { return }
+
+        AudioServicesPlaySystemSound(SystemSoundID(kSystemSoundID_Vibrate))
+        delegate?.didScanQRCode(stringValue)
+    }
+}

--- a/nightguard/external/DeviceRegistrationService.swift
+++ b/nightguard/external/DeviceRegistrationService.swift
@@ -1,0 +1,136 @@
+//
+//  DeviceRegistrationService.swift
+//  nightguard
+//
+//  Created by JamOrHam on 27/02/2026.
+//
+
+import Foundation
+
+// register our device information to the server for push notifications
+
+final class DeviceRegistrationService {
+
+    static let shared = DeviceRegistrationService()
+
+    private init() {}
+
+    // MARK: - Keys
+
+    private let tokenKey = "apns_token"
+    private let environmentKey = "apns_environment"
+    private let lastRegisteredTokenKey = "last_registered_token"
+
+    // MARK: - Computed URL
+
+    private var registrationURL: URL? {
+        UserDefaultsRepository
+            .getUrlWithPathAndQueryParameters(
+                path: "api/v1/registration",
+                queryParams: [:]
+            )
+    }
+
+    // MARK: - Public API
+
+    /// Called when token received
+    func updateDeviceToken(_ token: String, environment: String) {
+        UserDefaults.standard.set(token, forKey: tokenKey)
+        UserDefaults.standard.set(environment, forKey: environmentKey)
+
+        registerIfPossible()
+    }
+
+    /// Called when user finishes configuring server URL
+    func configurationDidUpdate() {
+        // Invalidate previous registration
+        UserDefaults.standard.removeObject(forKey: lastRegisteredTokenKey)
+
+        registerIfPossible()
+    }
+
+    /// Safe to call anytime
+    func registerIfPossible() {
+
+        guard
+            let token = UserDefaults.standard.string(forKey: tokenKey),
+            let environment = UserDefaults.standard.string(forKey: environmentKey),
+            let registrationURL = registrationURL
+        else {
+            Logger.log("Push registration: Missing token or registration URL. Skipping.")
+            return
+        }
+
+        // Avoid duplicate registrations
+        if token == UserDefaults.standard.string(forKey: lastRegisteredTokenKey) {
+            Logger.log("Push registration: Token already registered. Skipping.")
+            return
+        }
+
+        sendRegistration(token: token,
+                         environment: environment,
+                         url: registrationURL)
+    }
+    
+    // determine if this is sandbox apn or not
+    func apnsEnvironment() -> String {
+        guard
+            let url = Bundle.main.url(forResource: "embedded", withExtension: "mobileprovision"),
+            let data = try? Data(contentsOf: url),
+            let string = String(data: data, encoding: .ascii),
+            let range = string.range(of: "<key>aps-environment</key>")
+        else { return "error" }
+
+        let sub = string[range.upperBound...]
+        if sub.range(of: "<string>development</string>") != nil {
+            return "sandbox"
+        } else if sub.range(of: "<string>production</string>") != nil {
+            return "production"
+        }
+        return "unknown"
+    }
+    // MARK: - Private
+
+    private func sendRegistration(token: String,
+                                  environment: String,
+                                  url: URL) {
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let payload: [String: Any] = [
+            "deviceToken": token,
+            "environment": environment,
+            "bundle": Bundle.main.bundleIdentifier ?? "",
+            "platform": "ios"
+        ]
+
+        request.httpBody = try? JSONSerialization.data(withJSONObject: payload)
+
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+
+            if let error = error {
+                Logger.log("Push registration error: \(error)")
+                return
+            }
+
+            guard let httpResponse = response as? HTTPURLResponse else {
+                Logger.log("Push registration: Invalid server response")
+                return
+            }
+
+            if httpResponse.statusCode == 200 {
+                Logger.log("Push registration: Device successfully registered")
+
+                UserDefaults.standard.set(token,
+                                          forKey: self.lastRegisteredTokenKey)
+
+            } else {
+                Logger.log("Push registration: Bad status code: \(httpResponse.statusCode)")
+            }
+        }
+
+        task.resume()
+    }
+}

--- a/nightguard/external/Logger.swift
+++ b/nightguard/external/Logger.swift
@@ -1,0 +1,36 @@
+//
+//  Logger.swift
+//  nightguard
+//
+//  Created by JamOrHam on 27/02/2026.
+//
+
+import Foundation
+import os
+
+// Debug logger which records the timestamp, source file and line number in the output
+
+enum Logger {
+
+    private static let formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+        return formatter
+    }()
+    
+    private static let logger = os.Logger(subsystem: Bundle.main.bundleIdentifier ?? "unknown.bundle", category: "bg")
+    
+
+    static func log(
+        _ message: String,
+        file: String = #file,
+        function: String = #function,
+        line: Int = #line
+    ) {
+
+        let timestamp = formatter.string(from: Date())
+        let fileName = (file as NSString).lastPathComponent
+
+        logger.debug("[\(timestamp)] [\(fileName):\(line)] \(function) → \(message)")
+    }
+}

--- a/nightguard/helpers/QrCodeParser.swift
+++ b/nightguard/helpers/QrCodeParser.swift
@@ -1,0 +1,33 @@
+//
+//  QrCodeParser.swift
+//  nightguard
+//
+//  Created by JamOrHam on 27/02/2026.
+//
+
+import Foundation
+
+// Parse a Nightscout QR code and return the first endpoint string
+
+func extractEndpoint(from qrString: String) -> String {
+    guard let data = qrString.data(using: .utf8) else {
+        return ""
+    }
+
+    guard let jsonObject = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        return ""
+    }
+
+    let container = jsonObject["rest"] ?? jsonObject["nslite"]
+
+    guard let containerDict = container as? [String: Any] else {
+        return ""
+    }
+
+    guard let endpoints = containerDict["endpoint"] as? [String],
+          let firstEndpoint = endpoints.first else {
+        return ""
+    }
+
+    return firstEndpoint
+}

--- a/nightguard/views/AppTourView.swift
+++ b/nightguard/views/AppTourView.swift
@@ -142,13 +142,13 @@ struct ConfigurationTourPage: View {
                         }
                         .buttonStyle(PlainButtonStyle())
                     }
+                    QrScanSectionView(
+                        nightscoutURL: $nightscoutURL,
+                        onURLScanned: saveAndFinish
+                    )
                 }
             }
             
-            QrScanSectionView(
-                nightscoutURL: $nightscoutURL,
-                onURLScanned: saveAndFinish
-            )
             
             Section(
                 header: HStack {

--- a/nightguard/views/AppTourView.swift
+++ b/nightguard/views/AppTourView.swift
@@ -145,6 +145,11 @@ struct ConfigurationTourPage: View {
                 }
             }
             
+            QrScanSectionView(
+                nightscoutURL: $nightscoutURL,
+                onURLScanned: saveAndFinish
+            )
+            
             Section(
                 header: HStack {
                     Text(NSLocalizedString("API TOKEN", comment: ""))
@@ -296,6 +301,8 @@ struct ConfigurationTourPage: View {
         // Mark tour as seen
         UserDefaultsRepository.appTourSeen.value = true
         isPresented = false
+        
+        DeviceRegistrationService.shared.configurationDidUpdate()
     }
 }
 

--- a/nightguard/views/PrefsView.swift
+++ b/nightguard/views/PrefsView.swift
@@ -41,6 +41,11 @@ struct PrefsView: View {
                     validateAndSaveURL: validateAndSaveURL
                 )
                 
+                QrScanSectionView(
+                    nightscoutURL: $nightscoutURL,
+                    onURLScanned: validateAndSaveURL
+                )
+                
                 UnitsSectionView(
                     manuallySetUnits: $manuallySetUnits,
                     selectedUnits: $selectedUnits,
@@ -177,6 +182,8 @@ struct PrefsView: View {
         NightscoutDataRepository.singleton.storeYesterdaysBgData([])
         NightscoutDataRepository.singleton.storeCurrentNightscoutData(NightscoutData())
 
+        DeviceRegistrationService.shared.configurationDidUpdate()
+        
         retrieveAndStoreNightscoutUnits { error in
             isValidatingURL = false
 

--- a/nightguard/views/PrefsView.swift
+++ b/nightguard/views/PrefsView.swift
@@ -41,10 +41,7 @@ struct PrefsView: View {
                     validateAndSaveURL: validateAndSaveURL
                 )
                 
-                QrScanSectionView(
-                    nightscoutURL: $nightscoutURL,
-                    onURLScanned: validateAndSaveURL
-                )
+             
                 
                 UnitsSectionView(
                     manuallySetUnits: $manuallySetUnits,

--- a/nightguard/views/prefs/NightscoutSectionView.swift
+++ b/nightguard/views/prefs/NightscoutSectionView.swift
@@ -43,6 +43,10 @@ struct NightscoutSectionView: View {
                     ProgressView()
                         .progressViewStyle(CircularProgressViewStyle())
                 }
+                QrScanSectionView(
+                    nightscoutURL: $nightscoutURL,
+                    onURLScanned: validateAndSaveURL
+                )
             }
 
             if !urlErrorMessage.isEmpty {

--- a/nightguard/views/prefs/QRScannerViewRepresentable.swift
+++ b/nightguard/views/prefs/QRScannerViewRepresentable.swift
@@ -1,0 +1,43 @@
+//
+//  QRScannerViewRepresentable.swift
+//  nightguard
+//
+//  Created by JamOrHam on 27/02/2026.
+//
+
+import SwiftUI
+
+// Show the QR code scanner and return the result
+
+struct QRScannerViewRepresentable: UIViewControllerRepresentable {
+
+    var onScan: (String) -> Void
+
+    func makeUIViewController(context: Context) -> QRScannerViewController {
+        let vc = QRScannerViewController()
+        vc.delegate = context.coordinator
+        return vc
+    }
+
+    func updateUIViewController(_ uiViewController: QRScannerViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, QRScannerDelegate {
+        let parent: QRScannerViewRepresentable
+
+        init(_ parent: QRScannerViewRepresentable) {
+            self.parent = parent
+        }
+
+        func didScanQRCode(_ code: String) {
+            parent.onScan(code)
+        }
+
+        func didFailScanning(error: Error) {
+            print("Scan error:", error)
+        }
+    }
+}

--- a/nightguard/views/prefs/QrScanSectionView.swift
+++ b/nightguard/views/prefs/QrScanSectionView.swift
@@ -1,0 +1,42 @@
+//
+//  QrScanSectionView.swift
+//  nightguard
+//
+//  Created by JamOrHam on 27/02/2026.
+//
+
+import SwiftUI
+
+struct QrScanSectionView: View {
+    
+    // view for displaying QR code scan button and making callback with endpoint
+
+    @Binding var nightscoutURL: String
+    var onURLScanned: () -> Void
+
+    @State private var showQRScanner = false
+
+    var body: some View {
+        Section {
+            Button {
+                showQRScanner = true
+            } label: {
+                Label(NSLocalizedString("Scan QR code", comment: "QR code scan button title"), systemImage: "qrcode.viewfinder")
+            }
+        }
+        .sheet(isPresented: $showQRScanner) {
+            QRScannerViewRepresentable { scannedCode in
+                showQRScanner = false
+
+                let endpoint = extractEndpoint(from: scannedCode)
+
+                guard !endpoint.isEmpty else {
+                    return
+                }
+
+                nightscoutURL = endpoint
+                onURLScanned()
+            }
+        }
+    }
+}

--- a/nightguard/views/prefs/QrScanSectionView.swift
+++ b/nightguard/views/prefs/QrScanSectionView.swift
@@ -17,22 +17,23 @@ struct QrScanSectionView: View {
     @State private var showQRScanner = false
 
     var body: some View {
-        Section {
-            Button {
-                showQRScanner = true
-            } label: {
-                Label(NSLocalizedString("Scan QR code", comment: "QR code scan button title"), systemImage: "qrcode.viewfinder")
-            }
+        Button {
+            showQRScanner = true
+        } label: {
+            Image(systemName: "qrcode.viewfinder")
+                .font(.system(size: 18))
+                .foregroundColor(.accentColor)
+                .padding(3)
+                .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
         .sheet(isPresented: $showQRScanner) {
             QRScannerViewRepresentable { scannedCode in
                 showQRScanner = false
 
                 let endpoint = extractEndpoint(from: scannedCode)
 
-                guard !endpoint.isEmpty else {
-                    return
-                }
+                guard !endpoint.isEmpty else { return }
 
                 nightscoutURL = endpoint
                 onURLScanned()


### PR DESCRIPTION
What this PR does:

- Adds QR code scanning for Nightscout endpoint configuration.
- Adds elements to the `PrefsView` and `AppTourView` to allow the user to tap to then scan a QR code. 

I have an implementation in xDrip to produce these QR codes from the settings and they follow the original Nightscout standard schema which has been in xDrip for many years.

- The PR also obtains a device token for use with push messaging and uploads this to the Nightscout server. I have a server implementation which then can trigger push notifications that cause the app to wake up when readings are in alarm state within xDrip.

The main purpose of this is to allow the app to be woken up at important moments to sync data and to improve the experience of followers of xDrip but the new facilities can be applied universally with some additional work.

More work will also be needed to make this fully functional but these changes are the first step.

I hope you are happy with the structure and layout of what I've done here. Please let me know any comments/change requests. 

<img width="405" height="720" alt="nightguard-qr-IMG_0008" src="https://github.com/user-attachments/assets/9ed5e823-01e7-40bd-a414-8c1e198c6dad" />

